### PR TITLE
fix: allow vertical movement onto ramp tiles

### DIFF
--- a/src/application/use-cases/MovePlayerUseCase.js
+++ b/src/application/use-cases/MovePlayerUseCase.js
@@ -156,7 +156,13 @@ export class MovePlayerUseCase {
       return true;
     }
 
-    // For ramp tiles, check if we're approaching from the correct direction
+    // Allow vertical movement (up/down) onto any ramp tile
+    // Players should be able to step down onto ramps from above or climb up onto them
+    if (direction === 'up' || direction === 'down') {
+      return true;
+    }
+
+    // For horizontal movement, check directional constraints
     if (tileAtTarget.name === 'ramp_right') {
       // Ramp right (<) allows movement only when coming from the right (moving left)
       return direction === 'right';

--- a/tests/application/use-cases/MovePlayerUseCase.test.js
+++ b/tests/application/use-cases/MovePlayerUseCase.test.js
@@ -464,20 +464,22 @@ describe('MovePlayerUseCase', () => {
           expect(result).toBe(false);
         });
 
-        it('should block movement to ramp_right when moving up', () => {
+        it('should allow movement to ramp_right when moving up', () => {
+          // Vertical movement onto ramps should now be allowed
           mockMap.getTileAt.mockReturnValue({ name: 'ramp_right' });
 
           const result = movePlayerUseCase._isRampMovementAllowed(new Position(5, 4), 'up');
 
-          expect(result).toBe(false);
+          expect(result).toBe(true);
         });
 
-        it('should block movement to ramp_right when moving down', () => {
+        it('should allow movement to ramp_right when moving down', () => {
+          // Vertical movement onto ramps should now be allowed
           mockMap.getTileAt.mockReturnValue({ name: 'ramp_right' });
 
           const result = movePlayerUseCase._isRampMovementAllowed(new Position(5, 6), 'down');
 
-          expect(result).toBe(false);
+          expect(result).toBe(true);
         });
 
         it('should allow movement to ramp_left when moving right', () => {
@@ -496,20 +498,22 @@ describe('MovePlayerUseCase', () => {
           expect(result).toBe(false);
         });
 
-        it('should block movement to ramp_left when moving up', () => {
+        it('should allow movement to ramp_left when moving up', () => {
+          // Vertical movement onto ramps should now be allowed
           mockMap.getTileAt.mockReturnValue({ name: 'ramp_left' });
 
           const result = movePlayerUseCase._isRampMovementAllowed(new Position(5, 4), 'up');
 
-          expect(result).toBe(false);
+          expect(result).toBe(true);
         });
 
-        it('should block movement to ramp_left when moving down', () => {
+        it('should allow movement to ramp_left when moving down', () => {
+          // Vertical movement onto ramps should now be allowed
           mockMap.getTileAt.mockReturnValue({ name: 'ramp_left' });
 
           const result = movePlayerUseCase._isRampMovementAllowed(new Position(5, 6), 'down');
 
-          expect(result).toBe(false);
+          expect(result).toBe(true);
         });
 
         it('should handle null tile gracefully', () => {
@@ -545,6 +549,27 @@ describe('MovePlayerUseCase', () => {
           mockMap.getTileAt.mockReturnValue({ name: 'ramp_right' });
 
           const result = movePlayerUseCase._isPositionWalkable(new Position(6, 5));
+
+          expect(result).toBe(true);
+        });
+
+        it('should allow vertical movement DOWN onto ramp tiles', () => {
+          // This test reproduces the user's scenario: moving down from grass to ramp
+          mockMap.isWalkable.mockReturnValue(true);
+          mockMap.getTileAt.mockReturnValue({ name: 'ramp_left' });
+
+          // Should allow moving down onto a ramp tile
+          const result = movePlayerUseCase._isPositionWalkable(new Position(5, 6), 'down');
+
+          expect(result).toBe(true);
+        });
+
+        it('should allow vertical movement UP onto ramp tiles', () => {
+          // Should also allow moving up onto a ramp tile
+          mockMap.isWalkable.mockReturnValue(true);
+          mockMap.getTileAt.mockReturnValue({ name: 'ramp_right' });
+
+          const result = movePlayerUseCase._isPositionWalkable(new Position(5, 4), 'up');
 
           expect(result).toBe(true);
         });


### PR DESCRIPTION
Players were unable to move vertically (up/down) onto ramp tiles because the movement logic only allowed specific horizontal directions. This was particularly problematic when trying to step down from grass areas onto ramps, which should be a natural movement pattern.

The issue occurred because _isRampMovementAllowed only checked for:
- ramp_right tiles: only allowed when direction === 'right'
- ramp_left tiles: only allowed when direction === 'left'

Vertical movements (up/down) didn't match either condition, causing movement to be blocked even though ramp tiles are marked as walkable.

Solution implemented:
- Allow vertical movement (up/down) onto any ramp tile regardless of type
- Preserve existing horizontal directional constraints for ramp logic
- Players can now step down onto ramps from above or climb up onto them
- Maintains backward compatibility with existing ramp behavior