### PR TITLE
feat: enhance BlinkingGroveZone hidden area with gates, keys, and complete story

### DIFF
--- a/src/VimForKidsGame.js
+++ b/src/VimForKidsGame.js
@@ -394,18 +394,30 @@ export class VimForKidsGame {
 
         if (gateDestination && gateDestination.startsWith('vim_') && currentZone.getHiddenAreas().some(area => area.id === gateDestination)) {
           // Gate leads to a hidden area - reveal and enter it
+          console.log('🔄 REVEALING HIDDEN AREA:', gateDestination);
           const areasRevealed = currentZone.revealHiddenArea('escProgression');
+          console.log('🔄 AREAS REVEALED:', areasRevealed);
 
           if (areasRevealed) {
             // Enter the hidden area
+            console.log('🚪 ENTERING HIDDEN AREA:', gateDestination);
             const hiddenArea = currentZone.enterHiddenArea(gateDestination);
+            console.log('🚪 HIDDEN AREA ENTERED:', hiddenArea ? hiddenArea.id : 'FAILED');
 
             if (hiddenArea) {
               // Move player to hidden area start position
               const startPos = currentZone.getHiddenAreaStartPosition(gateDestination);
+              console.log('📍 MOVING TO START POSITION:', startPos ? `[${startPos.x}, ${startPos.y}]` : 'NONE');
               if (startPos) {
                 this.gameState.cursor = this.gameState.cursor.moveTo(startPos);
               }
+
+              // Debug: Check available keys after revealing
+              const currentState = this.gameState.getCurrentState();
+              console.log('🔑 COLLECTIBLE KEYS AFTER REVEAL:', currentState.availableCollectibleKeys?.map(k => ({ 
+                keyId: k.keyId, 
+                position: `[${k.position.x}, ${k.position.y}]` 
+              })));
 
               // Re-render to show the newly revealed areas and player position
               this.gameRenderer.render(this.gameState.getCurrentState());

--- a/src/VimForKidsGame.js
+++ b/src/VimForKidsGame.js
@@ -394,30 +394,18 @@ export class VimForKidsGame {
 
         if (gateDestination && gateDestination.startsWith('vim_') && currentZone.getHiddenAreas().some(area => area.id === gateDestination)) {
           // Gate leads to a hidden area - reveal and enter it
-          console.log('🔄 REVEALING HIDDEN AREA:', gateDestination);
           const areasRevealed = currentZone.revealHiddenArea('escProgression');
-          console.log('🔄 AREAS REVEALED:', areasRevealed);
 
           if (areasRevealed) {
             // Enter the hidden area
-            console.log('🚪 ENTERING HIDDEN AREA:', gateDestination);
             const hiddenArea = currentZone.enterHiddenArea(gateDestination);
-            console.log('🚪 HIDDEN AREA ENTERED:', hiddenArea ? hiddenArea.id : 'FAILED');
 
             if (hiddenArea) {
               // Move player to hidden area start position
               const startPos = currentZone.getHiddenAreaStartPosition(gateDestination);
-              console.log('📍 MOVING TO START POSITION:', startPos ? `[${startPos.x}, ${startPos.y}]` : 'NONE');
               if (startPos) {
                 this.gameState.cursor = this.gameState.cursor.moveTo(startPos);
               }
-
-              // Debug: Check available keys after revealing
-              const currentState = this.gameState.getCurrentState();
-              console.log('🔑 COLLECTIBLE KEYS AFTER REVEAL:', currentState.availableCollectibleKeys?.map(k => ({
-                keyId: k.keyId,
-                position: `[${k.position.x}, ${k.position.y}]`
-              })));
 
               // Re-render to show the newly revealed areas and player position
               this.gameRenderer.render(this.gameState.getCurrentState());

--- a/src/VimForKidsGame.js
+++ b/src/VimForKidsGame.js
@@ -414,9 +414,9 @@ export class VimForKidsGame {
 
               // Debug: Check available keys after revealing
               const currentState = this.gameState.getCurrentState();
-              console.log('🔑 COLLECTIBLE KEYS AFTER REVEAL:', currentState.availableCollectibleKeys?.map(k => ({ 
-                keyId: k.keyId, 
-                position: `[${k.position.x}, ${k.position.y}]` 
+              console.log('🔑 COLLECTIBLE KEYS AFTER REVEAL:', currentState.availableCollectibleKeys?.map(k => ({
+                keyId: k.keyId,
+                position: `[${k.position.x}, ${k.position.y}]`
               })));
 
               // Re-render to show the newly revealed areas and player position

--- a/src/application/TextlandGameState.js
+++ b/src/application/TextlandGameState.js
@@ -42,11 +42,9 @@ export class TextlandGameState {
   }
 
   collectCollectibleKey(collectibleKey) {
-    if (this.availableCollectibleKeys.includes(collectibleKey)) {
+    if (this.zone.collectibleKeys.includes(collectibleKey)) {
       this.collectedCollectibleKeys.add(collectibleKey.keyId);
-      this.availableCollectibleKeys = this.availableCollectibleKeys.filter(
-        (key) => key !== collectibleKey
-      );
+      // No need to filter cached array since we're using live zone data
 
       // Notify zone about key collection
       this.zone.collectKey(collectibleKey);
@@ -60,7 +58,7 @@ export class TextlandGameState {
       map: this.map,
       cursor: this.cursor,
       availableKeys: this.availableKeys,
-      availableCollectibleKeys: this.availableCollectibleKeys,
+      availableCollectibleKeys: this.zone.collectibleKeys, // Always get fresh keys from zone
       collectedKeys: this.collectedKeys,
       collectedCollectibleKeys: this.collectedCollectibleKeys,
       textLabels: this.zone.textLabels,

--- a/src/application/use-cases/MovePlayerUseCase.js
+++ b/src/application/use-cases/MovePlayerUseCase.js
@@ -409,12 +409,23 @@ export class MovePlayerUseCase {
   _checkKeyCollection() {
     const cursorPosition = this._gameState.cursor.position;
 
+    // Debug logging for key collection
+    console.log(`🎯 CHECKING KEY COLLECTION AT [${cursorPosition.x}, ${cursorPosition.y}]`);
+    if (this._gameState.availableCollectibleKeys?.length > 0) {
+      console.log('🔍 AVAILABLE COLLECTIBLE KEYS:', this._gameState.availableCollectibleKeys.map(k => ({ 
+        keyId: k.keyId, 
+        position: `[${k.position.x}, ${k.position.y}]`,
+        matches: k.position.equals(cursorPosition)
+      })));
+    }
+
     // Check for VIM keys
     const vimKeyAtPosition = this._gameState.availableKeys.find((key) =>
       key.position.equals(cursorPosition)
     );
 
     if (vimKeyAtPosition) {
+      console.log('✅ COLLECTING VIM KEY:', vimKeyAtPosition.key);
       this._gameState.collectKey(vimKeyAtPosition);
       this._gameRenderer.showKeyInfo(vimKeyAtPosition);
       return vimKeyAtPosition;
@@ -427,6 +438,7 @@ export class MovePlayerUseCase {
       );
 
       if (collectibleKeyAtPosition) {
+        console.log('✅ COLLECTING COLLECTIBLE KEY:', collectibleKeyAtPosition.keyId);
         if (typeof this._gameState.collectCollectibleKey === 'function') {
           this._gameState.collectCollectibleKey(collectibleKeyAtPosition);
         } else {

--- a/src/application/use-cases/MovePlayerUseCase.js
+++ b/src/application/use-cases/MovePlayerUseCase.js
@@ -152,7 +152,10 @@ export class MovePlayerUseCase {
     const tileAtTarget = this._gameState.map.getTileAt(targetPosition);
 
     // If it's not a ramp tile, allow movement (regular walkability rules apply)
-    if (!tileAtTarget || (tileAtTarget.name !== 'ramp_right' && tileAtTarget.name !== 'ramp_left')) {
+    if (
+      !tileAtTarget ||
+      (tileAtTarget.name !== 'ramp_right' && tileAtTarget.name !== 'ramp_left')
+    ) {
       return true;
     }
 
@@ -196,7 +199,7 @@ export class MovePlayerUseCase {
     return currentPosition.move(movement.x, movement.y);
   }
 
-      /**
+  /**
    * Calculate vertical movement with Vim-like column memory behavior
    * Column memory only applies to water tiles, not other obstacles
    * @private
@@ -293,7 +296,14 @@ export class MovePlayerUseCase {
       }
 
       // Check if this area is walkably connected to current position
-      if (endOfLeftmostArea && this._isWalkablyConnected(this._gameState.cursor.position, endOfLeftmostArea, maxSearchDistance)) {
+      if (
+        endOfLeftmostArea &&
+        this._isWalkablyConnected(
+          this._gameState.cursor.position,
+          endOfLeftmostArea,
+          maxSearchDistance
+        )
+      ) {
         return endOfLeftmostArea;
       }
     }
@@ -306,7 +316,9 @@ export class MovePlayerUseCase {
       const position = new Position(x, targetY);
       if (this._isPositionWalkable(position)) {
         // Check if this position is walkably connected
-        if (this._isWalkablyConnected(this._gameState.cursor.position, position, maxSearchDistance)) {
+        if (
+          this._isWalkablyConnected(this._gameState.cursor.position, position, maxSearchDistance)
+        ) {
           return position;
         }
       }
@@ -335,7 +347,10 @@ export class MovePlayerUseCase {
     // For vertical movement, check if there's a walkable bridge between the rows
     // We need to find a column that's walkable in both rows within the maxDistance
     const minX = Math.max(0, Math.min(fromPosition.x, toPosition.x) - maxDistance);
-    const maxX = Math.min(this._gameState.map.width - 1, Math.max(fromPosition.x, toPosition.x) + maxDistance);
+    const maxX = Math.min(
+      this._gameState.map.width - 1,
+      Math.max(fromPosition.x, toPosition.x) + maxDistance
+    );
 
     for (let x = minX; x <= maxX; x++) {
       const fromRowPosition = new Position(x, fromPosition.y);
@@ -344,8 +359,10 @@ export class MovePlayerUseCase {
       // Check if this column provides a walkable bridge
       if (this._isPositionWalkable(fromRowPosition) && this._isPositionWalkable(toRowPosition)) {
         // Check if we can reach this bridge from both positions horizontally
-        if (this._areHorizontallyConnected(fromPosition, fromRowPosition, maxDistance) &&
-            this._areHorizontallyConnected(toPosition, toRowPosition, maxDistance)) {
+        if (
+          this._areHorizontallyConnected(fromPosition, fromRowPosition, maxDistance) &&
+          this._areHorizontallyConnected(toPosition, toRowPosition, maxDistance)
+        ) {
           return true;
         }
       }
@@ -409,15 +426,7 @@ export class MovePlayerUseCase {
   _checkKeyCollection() {
     const cursorPosition = this._gameState.cursor.position;
 
-    // Debug logging for key collection
-    console.log(`🎯 CHECKING KEY COLLECTION AT [${cursorPosition.x}, ${cursorPosition.y}]`);
-    if (this._gameState.availableCollectibleKeys?.length > 0) {
-      console.log('🔍 AVAILABLE COLLECTIBLE KEYS:', this._gameState.availableCollectibleKeys.map(k => ({
-        keyId: k.keyId,
-        position: `[${k.position.x}, ${k.position.y}]`,
-        matches: k.position.equals(cursorPosition)
-      })));
-    }
+
 
     // Check for VIM keys
     const vimKeyAtPosition = this._gameState.availableKeys.find((key) =>
@@ -432,13 +441,15 @@ export class MovePlayerUseCase {
     }
 
     // Check for CollectibleKeys
-    if (this._gameState.availableCollectibleKeys) {
-      const collectibleKeyAtPosition = this._gameState.availableCollectibleKeys.find((key) =>
+    // Get fresh keys from getCurrentState() instead of stale property
+    const currentState = this._gameState.getCurrentState();
+
+    if (currentState.availableCollectibleKeys) {
+      const collectibleKeyAtPosition = currentState.availableCollectibleKeys.find((key) =>
         key.position.equals(cursorPosition)
       );
 
       if (collectibleKeyAtPosition) {
-        console.log('✅ COLLECTING COLLECTIBLE KEY:', collectibleKeyAtPosition.keyId);
         if (typeof this._gameState.collectCollectibleKey === 'function') {
           this._gameState.collectCollectibleKey(collectibleKeyAtPosition);
         } else {
@@ -488,7 +499,7 @@ export class MovePlayerUseCase {
   _hasNPCAtPosition(position, gameState) {
     // Check if there's an NPC at the given position
     const npcs = gameState.npcs || [];
-    return npcs.some(npc => {
+    return npcs.some((npc) => {
       if (!npc.position) {
         return false;
       }
@@ -499,7 +510,11 @@ export class MovePlayerUseCase {
       }
 
       // Handle plain objects with x,y properties
-      if (typeof npc.position === 'object' && npc.position.x !== undefined && npc.position.y !== undefined) {
+      if (
+        typeof npc.position === 'object' &&
+        npc.position.x !== undefined &&
+        npc.position.y !== undefined
+      ) {
         return npc.position.x === position.x && npc.position.y === position.y;
       }
 

--- a/src/application/use-cases/MovePlayerUseCase.js
+++ b/src/application/use-cases/MovePlayerUseCase.js
@@ -412,8 +412,8 @@ export class MovePlayerUseCase {
     // Debug logging for key collection
     console.log(`🎯 CHECKING KEY COLLECTION AT [${cursorPosition.x}, ${cursorPosition.y}]`);
     if (this._gameState.availableCollectibleKeys?.length > 0) {
-      console.log('🔍 AVAILABLE COLLECTIBLE KEYS:', this._gameState.availableCollectibleKeys.map(k => ({ 
-        keyId: k.keyId, 
+      console.log('🔍 AVAILABLE COLLECTIBLE KEYS:', this._gameState.availableCollectibleKeys.map(k => ({
+        keyId: k.keyId,
         position: `[${k.position.x}, ${k.position.y}]`,
         matches: k.position.equals(cursorPosition)
       })));

--- a/src/domain/entities/DynamicZoneMap.js
+++ b/src/domain/entities/DynamicZoneMap.js
@@ -105,6 +105,49 @@ export class DynamicZoneMap {
     return this.zoneStartY + this._zoneHeight;
   }
 
+  /**
+   * Expand map dimensions to accommodate hidden areas
+   * @param {number} requiredWidth - Minimum required width
+   * @param {number} requiredHeight - Minimum required height
+   */
+  expandDimensions(requiredWidth, requiredHeight) {
+    const oldWidth = this._width;
+    const oldHeight = this._height;
+
+    // Expand dimensions if needed
+    this._width = Math.max(this._width, requiredWidth);
+    this._height = Math.max(this._height, requiredHeight);
+
+    // If dimensions changed, we need to expand the tile grid
+    if (this._width > oldWidth || this._height > oldHeight) {
+      this._expandTileGrid(oldWidth, oldHeight);
+    }
+  }
+
+  /**
+   * Expand the tile grid to accommodate new dimensions
+   * @private
+   */
+  _expandTileGrid(oldWidth, oldHeight) {
+    const newTiles = [];
+
+    // Create new expanded grid
+    for (let y = 0; y < this._height; y++) {
+      newTiles[y] = [];
+      for (let x = 0; x < this._width; x++) {
+        if (y < oldHeight && x < oldWidth && this._tiles[y] && this._tiles[y][x]) {
+          // Copy existing tile
+          newTiles[y][x] = this._tiles[y][x];
+        } else {
+          // Fill new areas with water
+          newTiles[y][x] = TileType.WATER;
+        }
+      }
+    }
+
+    this._tiles = newTiles;
+  }
+
   _initializeMap() {
     // Create large grid with water filling entire screen
     this._tiles = [];

--- a/src/domain/entities/Gate.js
+++ b/src/domain/entities/Gate.js
@@ -1,7 +1,7 @@
 import { Position } from '../value-objects/Position.js';
 
 export class Gate {
-  constructor(position, unlockConditions = null) {
+  constructor(position, unlockConditions = null, leadsTo = null) {
     if (!(position instanceof Position)) {
       throw new Error('Position must be a valid Position object');
     }
@@ -10,6 +10,7 @@ export class Gate {
     this._isOpen = false;
     this._type = 'gate';
     this._unlockConditions = unlockConditions || {};
+    this._leadsTo = leadsTo;
 
     // Make properties immutable
     Object.defineProperty(this, 'position', {
@@ -20,6 +21,12 @@ export class Gate {
 
     Object.defineProperty(this, 'type', {
       value: this._type,
+      writable: false,
+      configurable: false,
+    });
+
+    Object.defineProperty(this, 'leadsTo', {
+      value: this._leadsTo,
       writable: false,
       configurable: false,
     });

--- a/src/domain/entities/TextLabel.js
+++ b/src/domain/entities/TextLabel.js
@@ -1,7 +1,7 @@
 import { Position } from '../value-objects/Position.js';
 
 export class TextLabel {
-  constructor(position, text) {
+  constructor(position, text, options = {}) {
     if (!(position instanceof Position)) {
       throw new Error('Position must be a valid Position object');
     }
@@ -14,8 +14,9 @@ export class TextLabel {
     this._text = text;
     this._type = 'textLabel';
     this._isVisible = true;
-    this._color = '#2c3e50'; // Dark color for readability
-    this._fontSize = '12px';
+    this._color = options.color || '#2c3e50'; // Default or custom color
+    this._fontSize = options.fontSize || '12px'; // Default or custom fontSize
+    this._fontWeight = options.fontWeight || 'normal'; // Support fontWeight
 
     // Make properties immutable
     Object.defineProperty(this, 'position', {
@@ -47,6 +48,10 @@ export class TextLabel {
 
   get fontSize() {
     return this._fontSize;
+  }
+
+  get fontWeight() {
+    return this._fontWeight;
   }
 
   equals(other) {

--- a/src/domain/entities/Zone.js
+++ b/src/domain/entities/Zone.js
@@ -57,6 +57,10 @@ export class Zone {
   }
 
   get collectibleKeys() {
+    console.log('🔑 ZONE.COLLECTIBLEKEYS GETTER CALLED:', this._collectibleKeys?.length || 0, 'keys available');
+    if (this._collectibleKeys?.length > 0) {
+      console.log('🔑 KEYS DETAILS:', this._collectibleKeys.map(k => ({ keyId: k.keyId, position: `[${k.position.x}, ${k.position.y}]` })));
+    }
     return [...this._collectibleKeys];
   }
 
@@ -265,8 +269,12 @@ export class Zone {
   }
 
     _buildCollectibleKeys(specialTiles) {
+    console.log('🏗️ _buildCollectibleKeys CALLED with', specialTiles?.length || 0, 'tiles');
+    console.log('🏗️ Current _collectibleKeys array length:', this._collectibleKeys?.length || 0);
+    
     // Initialize the array only if it doesn't exist (first time)
     if (!this._collectibleKeys) {
+      console.log('🏗️ Initializing new _collectibleKeys array');
       this._collectibleKeys = [];
     }
 
@@ -284,7 +292,11 @@ export class Zone {
           // Check if this key already exists (avoid duplicates)
           const existingKey = this._collectibleKeys.find(k => k.keyId === keyId);
           if (!existingKey) {
+            console.log('🔑 ADDING NEW COLLECTIBLE KEY:', keyId, `at [${absolutePosition.x}, ${absolutePosition.y}]`);
             this._collectibleKeys.push(new CollectibleKey(absolutePosition, keyId, name, color));
+            console.log('🔑 Total keys after addition:', this._collectibleKeys.length);
+          } else {
+            console.log('🔑 SKIPPING DUPLICATE KEY:', keyId);
           }
         }
       });

--- a/src/domain/entities/Zone.js
+++ b/src/domain/entities/Zone.js
@@ -264,7 +264,7 @@ export class Zone {
     }
   }
 
-  _buildCollectibleKeys(specialTiles) {
+    _buildCollectibleKeys(specialTiles) {
     // Initialize the array only if it doesn't exist (first time)
     if (!this._collectibleKeys) {
       this._collectibleKeys = [];
@@ -585,7 +585,7 @@ export class Zone {
    * Internal method to reveal a specific hidden area
    * @private
    */
-  _revealHiddenArea(area) {
+    _revealHiddenArea(area) {
     // Calculate required map dimensions for this hidden area
     if (area.layout && area.layout.length > 0) {
       const hiddenAreaWidth = area.layout[0] ? area.layout[0].length : 0;
@@ -676,7 +676,7 @@ export class Zone {
         // Convert to absolute coordinates: zoneStart + hiddenAreaPosition + offset
         const absoluteX = this._gameMap.zoneStartX + gate.position[0] + (area.offsetX || 0);
         const absoluteY = this._gameMap.zoneStartY + gate.position[1] + (area.offsetY || 0);
-        
+
         return {
           ...gate,
           position: [absoluteX, absoluteY],

--- a/src/domain/entities/Zone.js
+++ b/src/domain/entities/Zone.js
@@ -335,11 +335,10 @@ export class Zone {
     if (secondaryGatesConfig && Array.isArray(secondaryGatesConfig)) {
       secondaryGatesConfig.forEach((gateConfig) => {
         if (gateConfig && gateConfig.position) {
-          // Convert zone-relative coordinates to absolute coordinates
-          const absolutePosition = this._gameMap.zoneToAbsolute(
-            gateConfig.position[0],
-            gateConfig.position[1]
-          );
+          // Convert coordinates to absolute - skip conversion for hidden area gates as they're already absolute
+          const absolutePosition = gateConfig.isFromHiddenArea
+            ? new Position(gateConfig.position[0], gateConfig.position[1])
+            : this._gameMap.zoneToAbsolute(gateConfig.position[0], gateConfig.position[1]);
 
           // Check if this gate already exists (avoid duplicates)
           const existingGate = this._secondaryGates.find(g => g.position.equals(absolutePosition));
@@ -656,7 +655,7 @@ export class Zone {
         // Convert to absolute coordinates: zoneStart + hiddenAreaPosition + offset
         const absoluteX = this._gameMap.zoneStartX + tile.position[0] + (area.offsetX || 0);
         const absoluteY = this._gameMap.zoneStartY + tile.position[1] + (area.offsetY || 0);
-        
+
         const adjustedTile = {
           ...tile,
           position: [absoluteX, absoluteY],
@@ -671,7 +670,7 @@ export class Zone {
       });
     }
 
-    // Add secondary gates from the hidden area
+        // Add secondary gates from the hidden area
     if (area.secondaryGates) {
       const adjustedGates = area.secondaryGates.map(gate => {
         // Convert to absolute coordinates: zoneStart + hiddenAreaPosition + offset
@@ -680,7 +679,8 @@ export class Zone {
         
         return {
           ...gate,
-          position: [absoluteX, absoluteY]
+          position: [absoluteX, absoluteY],
+          isFromHiddenArea: true // Mark as already having absolute coordinates
         };
       });
       this._buildSecondaryGates(adjustedGates);

--- a/src/domain/entities/Zone.js
+++ b/src/domain/entities/Zone.js
@@ -57,10 +57,6 @@ export class Zone {
   }
 
   get collectibleKeys() {
-    console.log('🔑 ZONE.COLLECTIBLEKEYS GETTER CALLED:', this._collectibleKeys?.length || 0, 'keys available');
-    if (this._collectibleKeys?.length > 0) {
-      console.log('🔑 KEYS DETAILS:', this._collectibleKeys.map(k => ({ keyId: k.keyId, position: `[${k.position.x}, ${k.position.y}]` })));
-    }
     return [...this._collectibleKeys];
   }
 
@@ -268,13 +264,9 @@ export class Zone {
     }
   }
 
-    _buildCollectibleKeys(specialTiles) {
-    console.log('🏗️ _buildCollectibleKeys CALLED with', specialTiles?.length || 0, 'tiles');
-    console.log('🏗️ Current _collectibleKeys array length:', this._collectibleKeys?.length || 0);
-    
+        _buildCollectibleKeys(specialTiles) {
     // Initialize the array only if it doesn't exist (first time)
     if (!this._collectibleKeys) {
-      console.log('🏗️ Initializing new _collectibleKeys array');
       this._collectibleKeys = [];
     }
 
@@ -292,11 +284,7 @@ export class Zone {
           // Check if this key already exists (avoid duplicates)
           const existingKey = this._collectibleKeys.find(k => k.keyId === keyId);
           if (!existingKey) {
-            console.log('🔑 ADDING NEW COLLECTIBLE KEY:', keyId, `at [${absolutePosition.x}, ${absolutePosition.y}]`);
             this._collectibleKeys.push(new CollectibleKey(absolutePosition, keyId, name, color));
-            console.log('🔑 Total keys after addition:', this._collectibleKeys.length);
-          } else {
-            console.log('🔑 SKIPPING DUPLICATE KEY:', keyId);
           }
         }
       });

--- a/src/domain/entities/Zone.js
+++ b/src/domain/entities/Zone.js
@@ -653,12 +653,13 @@ export class Zone {
     // Add special tiles from the hidden area
     if (area.specialTiles) {
       area.specialTiles.forEach(tile => {
+        // Convert to absolute coordinates: zoneStart + hiddenAreaPosition + offset
+        const absoluteX = this._gameMap.zoneStartX + tile.position[0] + (area.offsetX || 0);
+        const absoluteY = this._gameMap.zoneStartY + tile.position[1] + (area.offsetY || 0);
+        
         const adjustedTile = {
           ...tile,
-          position: [
-            tile.position[0] + (area.offsetX || 0),
-            tile.position[1] + (area.offsetY || 0)
-          ],
+          position: [absoluteX, absoluteY],
           isFromHiddenArea: true // Mark as already having absolute coordinates
         };
 
@@ -672,13 +673,16 @@ export class Zone {
 
     // Add secondary gates from the hidden area
     if (area.secondaryGates) {
-      const adjustedGates = area.secondaryGates.map(gate => ({
-        ...gate,
-        position: [
-          gate.position[0] + (area.offsetX || 0),
-          gate.position[1] + (area.offsetY || 0)
-        ]
-      }));
+      const adjustedGates = area.secondaryGates.map(gate => {
+        // Convert to absolute coordinates: zoneStart + hiddenAreaPosition + offset
+        const absoluteX = this._gameMap.zoneStartX + gate.position[0] + (area.offsetX || 0);
+        const absoluteY = this._gameMap.zoneStartY + gate.position[1] + (area.offsetY || 0);
+        
+        return {
+          ...gate,
+          position: [absoluteX, absoluteY]
+        };
+      });
       this._buildSecondaryGates(adjustedGates);
     }
   }

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -429,11 +429,7 @@ export class BlinkingGroveZone {
               { text: ')', position: [31, 9], color: '#ffa726', fontSize: '14px' },
             ],
             specialTiles: [
-              // Add some special vim keys as rewards in the hidden area (positioned on the path)
-              { type: 'collectible_key', keyId: 'secret_vim_key', name: 'Secret Vim Key', color: '#FFD700', position: [15, 10] },
-              { type: 'collectible_key', keyId: 'master_key', name: 'Master Key', color: '#FF6B6B', position: [50, 10] },
-
-              // Three new keys positioned near the letters (not on top to avoid text overlap)
+              // Three keys positioned near the letters for the three gates
               { type: 'collectible_key', keyId: 'golden_key', name: 'Golden Key', color: '#FFD700', position: [19, 0] }, // Next to 'm' in 'vim'
               { type: 'collectible_key', keyId: 'silver_key', name: 'Silver Key', color: '#C0C0C0', position: [25, 0] }, // Next to 'l' in 'Total'
               { type: 'collectible_key', keyId: 'bronze_key', name: 'Bronze Key', color: '#CD7F32', position: [31, 0] }, // Next to 'z' in 'Rulez'

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -56,7 +56,7 @@ export class BlinkingGroveZone {
           'GGGGGGGGGDGGSSSSSDSSSSSDSSSSSSSSSDSDSSSSSSSSSSDSDSSSDSDSWWWWWWWWWWWWWWWWWWW',
           'GTGGGGGGGDDDDDDDDDSDDDSDSDDDDDDDSDSDSDDDDDDDDDDSD<DDDSDSWWWWWWWWWWWWWWWWWWW',
           'GGGGGGGGGGGGSSSSSDSSSDSDSDSSSSSSSDSDSSSSSSSSSSSSDSSSSSDSWWWWWWWWWWWWWWWWWWW',
-          'WWWWWWWWWWWWWWWWSD<DDDDDDDDDDDDDDDSDDDDDDDDDDDDDD>DDDDDSWWWWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWSD<DDDDDDDDDDDDDDD<DDDDDDDDDDDDDD>DDDDDSWWWWWWWWWWWWWWWWWWW',
           'WWWWWWWWWWWWWWWWSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSWWWWWWWWWWWWWWWWWWW',
           'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
         ],
@@ -128,9 +128,347 @@ export class BlinkingGroveZone {
         gate: {
           locked: true,
           unlocksWhen: { collectedVimKeys: ['h', 'j', 'k', 'l'] }, // Gate auto-unlocks when keys collected
-          position: [74, 1], // Gate position in the stone maze
-          leadsTo: 'zone_2',
+          position: [74, 1], // Gate position to connect with hidden area
+          leadsTo: 'vim_secret_area', // First leads to hidden area, not directly to zone_2
         },
+        hiddenAreas: [
+          {
+            id: 'vim_secret_area',
+            revealWhen: 'escProgression',
+            layout: [
+          'DWWWWWWWWWWWWWWWPPPPPPPPPPPPPPPPPPPPWWWWWWWWWWWWWWWW',
+          'PWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+          'PDWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPPPWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPWWDWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPPPPPPPPWWWWWWDWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPPPPPWWWWWWWWWDWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPWWWWWWWWWWWWPPPPPPWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPWWWWWWWWPPPPPPWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPPWWWWWWWPPPPPPWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPPPPWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+          'PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPDWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWGWWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWGWWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWGWWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+        ],
+            legend: {
+              W: 'water',
+              D: 'dirt',
+              P: 'path',
+              G: 'gate',
+            },
+            offsetX: 56, // Positioned to connect directly to the main area
+            offsetY: 1, // Same vertical level as the main area
+            textLabels: [
+              // "vim Total Rulez!!!" text in the hidden area (centered in the wider area)
+              { text: 'v', position: [16, 0], color: '#ff6b6b', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'i', position: [17, 0], color: '#ff6b6b', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'm', position: [18, 0], color: '#ff6b6b', fontSize: '20px', fontWeight: 'bold' },
+
+              { text: 'T', position: [20, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'o', position: [21, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold' },
+              { text: 't', position: [22, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'a', position: [23, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'l', position: [24, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold' },
+
+              { text: 'R', position: [26, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'u', position: [27, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'l', position: [28, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'e', position: [29, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold' },
+              { text: 'z', position: [30, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold' },
+
+              { text: '!', position: [32, 0], color: '#f7dc6f', fontSize: '24px', fontWeight: 'bold' },
+              { text: '!', position: [33, 0], color: '#f7dc6f', fontSize: '24px', fontWeight: 'bold' },
+              { text: '!', position: [34, 0], color: '#f7dc6f', fontSize: '24px', fontWeight: 'bold' },
+
+              // Additional encouraging text
+              { text: 'T', position: [0, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [1, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [2, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [3, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [4, 3], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'w', position: [5, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'i', position: [6, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [7, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [8, 3], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'c', position: [10, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [11, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'm', position: [12, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [13, 3], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'a', position: [15, 3], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 't', position: [17, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'i', position: [18, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'm', position: [19, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [20, 3], color: '#95e1d3', fontSize: '16px' },
+              { text: ',', position: [21, 3], color: '#95e1d3', fontSize: '16px' },
+
+              // "Before open source's golden era," - Line 4
+              { text: 'B', position: [0, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [1, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'f', position: [2, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [3, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [4, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [5, 4], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'o', position: [7, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'p', position: [8, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [9, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [10, 4], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 's', position: [12, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [13, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'u', position: [14, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [15, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'c', position: [16, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [17, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: '\'', position: [18, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [19, 4], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'g', position: [21, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [22, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [23, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [24, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [25, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [26, 4], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'e', position: [28, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [29, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: 'a', position: [30, 4], color: '#95e1d3', fontSize: '16px' },
+              { text: ',', position: [31, 4], color: '#95e1d3', fontSize: '16px' },
+
+              // "When the bugs rule the land," - Line 5
+              { text: 'W', position: [0, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [1, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [2, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [3, 5], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 't', position: [5, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [6, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [7, 5], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'b', position: [9, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'u', position: [10, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'g', position: [11, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [12, 5], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'r', position: [14, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'u', position: [15, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [16, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [17, 5], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 't', position: [19, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [20, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [21, 5], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'l', position: [23, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'a', position: [24, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [25, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [26, 5], color: '#95e1d3', fontSize: '16px' },
+              { text: ',', position: [27, 5], color: '#95e1d3', fontSize: '16px' },
+
+              // "And the darkness is deep." - Line 6
+              { text: 'A', position: [0, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [1, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [2, 6], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 't', position: [4, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [5, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [6, 6], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'd', position: [8, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'a', position: [9, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [10, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'k', position: [11, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [12, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [13, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [14, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [15, 6], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'i', position: [17, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [18, 6], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'd', position: [20, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [21, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [22, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: 'p', position: [23, 6], color: '#95e1d3', fontSize: '16px' },
+              { text: '.', position: [24, 6], color: '#95e1d3', fontSize: '16px' },
+
+              // "But from the shadows emerge," - Line 8
+              { text: 'B', position: [0, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'u', position: [1, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 't', position: [2, 8], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'f', position: [4, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [5, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [6, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'm', position: [7, 8], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 't', position: [9, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [10, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [11, 8], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 's', position: [13, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [14, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'a', position: [15, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [16, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [17, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 'w', position: [18, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [19, 8], color: '#95e1d3', fontSize: '16px' },
+              { text: ',', position: [20, 8], color: '#95e1d3', fontSize: '16px' },
+
+
+              // "A shady one emerges." - Line 9
+              { text: 'A', position: [0, 9], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 's', position: [2, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [3, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'a', position: [4, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [5, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [6, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'w', position: [7, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'y', position: [8, 9], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'o', position: [10, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [11, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [12, 9], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'e', position: [14, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'm', position: [15, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [16, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [17, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'g', position: [18, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [19, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [20, 9], color: '#95e1d3', fontSize: '16px' },
+              { text: ',', position: [21, 9], color: '#95e1d3', fontSize: '16px' },
+
+              // "To restore the old code." - Line 10
+              { text: 'T', position: [0, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [1, 10], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'r', position: [3, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [4, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 's', position: [5, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 't', position: [6, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [7, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [8, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [9, 10], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 't', position: [11, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [12, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [13, 10], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'o', position: [15, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [17, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [18, 10], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'c', position: [20, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [21, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [22, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [23, 10], color: '#95e1d3', fontSize: '16px' },
+              { text: ',', position: [24, 10], color: '#95e1d3', fontSize: '16px' },
+
+              // "And the power of VIM will prevail." - Line 11
+              { text: 'A', position: [0, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'n', position: [1, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'd', position: [2, 12], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 't', position: [4, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'h', position: [5, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [6, 12], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'p', position: [8, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'o', position: [9, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'w', position: [10, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [11, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [12, 12], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'o', position: [14, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'f', position: [15, 12], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'V', position: [17, 12], color: '#ff6b6b', fontSize: '16px', fontWeight: 'bold' },
+              { text: 'I', position: [18, 12], color: '#ff6b6b', fontSize: '16px', fontWeight: 'bold' },
+              { text: 'M', position: [19, 12], color: '#ff6b6b', fontSize: '16px', fontWeight: 'bold' },
+
+              { text: 'w', position: [21, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'i', position: [22, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [23, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [24, 12], color: '#95e1d3', fontSize: '16px' },
+
+              { text: 'p', position: [26, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'r', position: [27, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'e', position: [28, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'v', position: [29, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'a', position: [30, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'i', position: [31, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: 'l', position: [32, 12], color: '#95e1d3', fontSize: '16px' },
+              { text: '.', position: [33, 12], color: '#95e1d3', fontSize: '16px' },
+
+              // Secret message
+              { text: 'N', position: [30, 7], color: '#ffa726', fontSize: '14px' },
+              { text: 'o', position: [31, 7], color: '#ffa726', fontSize: '14px' },
+              { text: 'w', position: [32, 7], color: '#ffa726', fontSize: '14px' },
+
+              { text: 'g', position: [34, 7], color: '#ffa726', fontSize: '14px' },
+              { text: 'o', position: [35, 7], color: '#ffa726', fontSize: '14px' },
+
+              { text: 'b', position: [30, 8], color: '#ffa726', fontSize: '14px' },
+              { text: 'a', position: [31, 8], color: '#ffa726', fontSize: '14px' },
+              { text: 'c', position: [32, 8], color: '#ffa726', fontSize: '14px' },
+              { text: 'k', position: [33, 8], color: '#ffa726', fontSize: '14px' },
+
+              { text: ':', position: [30, 9], color: '#ffa726', fontSize: '14px' },
+              { text: ')', position: [31, 9], color: '#ffa726', fontSize: '14px' },
+            ],
+            specialTiles: [
+              // Add some special vim keys as rewards in the hidden area (positioned on the path)
+              { type: 'collectible_key', keyId: 'secret_vim_key', name: 'Secret Vim Key', color: '#FFD700', position: [15, 10] },
+              { type: 'collectible_key', keyId: 'master_key', name: 'Master Key', color: '#FF6B6B', position: [50, 10] },
+
+              // Three new keys positioned near the letters (not on top to avoid text overlap)
+              { type: 'collectible_key', keyId: 'golden_key', name: 'Golden Key', color: '#FFD700', position: [19, 0] }, // Next to 'm' in 'vim'
+              { type: 'collectible_key', keyId: 'silver_key', name: 'Silver Key', color: '#C0C0C0', position: [25, 0] }, // Next to 'l' in 'Total'
+              { type: 'collectible_key', keyId: 'bronze_key', name: 'Bronze Key', color: '#CD7F32', position: [31, 0] }, // Next to 'z' in 'Rulez'
+            ],
+            // Player starts here when entering the hidden area (just inside from the gate)
+            playerStartPosition: [0, 0], // Just inside the hidden area, right after the connection
+            // Gate in the hidden area that leads to the real next level
+            gate: {
+              locked: false, // Unlocked - player earned access by reaching hidden area
+              position: [73, 10], // Gate position in the hidden area (on the dirt path at the far right)
+              leadsTo: 'zone_2', // This gate leads to the actual next zone
+            },
+            // Secondary gates within the hidden area that require specific keys
+            secondaryGates: [
+              {
+                locked: true,
+                unlocksWhen: { requiredCollectibleKeys: ['golden_key'] },
+                position: [34, 13], // First gate in hidden area (relative to hidden area grid)
+                leadsTo: 'golden_chamber',
+              },
+              {
+                locked: true,
+                unlocksWhen: { requiredCollectibleKeys: ['silver_key'] },
+                position: [34, 14], // Second gate in hidden area (relative to hidden area grid)
+                leadsTo: 'silver_chamber',
+              },
+              {
+                locked: true,
+                unlocksWhen: { requiredCollectibleKeys: ['bronze_key'] },
+                position: [34, 15], // Third gate in hidden area (relative to hidden area grid)
+                leadsTo: 'bronze_chamber',
+              },
+            ],
+          },
+        ],
         secondaryGates: [
           {
             locked: true,

--- a/src/infrastructure/ui/DOMGameRenderer.js
+++ b/src/infrastructure/ui/DOMGameRenderer.js
@@ -258,13 +258,13 @@ export class DOMGameRenderer extends GameRenderer {
   render(gameState) {
     // Debug logging for hidden area keys
     if (gameState.availableCollectibleKeys && gameState.availableCollectibleKeys.length > 0) {
-      console.log('🔑 AVAILABLE COLLECTIBLE KEYS:', gameState.availableCollectibleKeys.map(k => ({ 
-        keyId: k.keyId, 
+      console.log('🔑 AVAILABLE COLLECTIBLE KEYS:', gameState.availableCollectibleKeys.map(k => ({
+        keyId: k.keyId,
         position: `[${k.position.x}, ${k.position.y}]`,
-        name: k.name 
+        name: k.name
       })));
     }
-    
+
     this._updateCamera(gameState);
     this.gameBoard.innerHTML = '';
 

--- a/src/infrastructure/ui/DOMGameRenderer.js
+++ b/src/infrastructure/ui/DOMGameRenderer.js
@@ -256,6 +256,15 @@ export class DOMGameRenderer extends GameRenderer {
   }
 
   render(gameState) {
+    // Debug logging for hidden area keys
+    if (gameState.availableCollectibleKeys && gameState.availableCollectibleKeys.length > 0) {
+      console.log('🔑 AVAILABLE COLLECTIBLE KEYS:', gameState.availableCollectibleKeys.map(k => ({ 
+        keyId: k.keyId, 
+        position: `[${k.position.x}, ${k.position.y}]`,
+        name: k.name 
+      })));
+    }
+    
     this._updateCamera(gameState);
     this.gameBoard.innerHTML = '';
 

--- a/src/infrastructure/ui/DOMGameRenderer.js
+++ b/src/infrastructure/ui/DOMGameRenderer.js
@@ -256,15 +256,6 @@ export class DOMGameRenderer extends GameRenderer {
   }
 
   render(gameState) {
-    // Debug logging for hidden area keys
-    if (gameState.availableCollectibleKeys && gameState.availableCollectibleKeys.length > 0) {
-      console.log('🔑 AVAILABLE COLLECTIBLE KEYS:', gameState.availableCollectibleKeys.map(k => ({
-        keyId: k.keyId,
-        position: `[${k.position.x}, ${k.position.y}]`,
-        name: k.name
-      })));
-    }
-
     this._updateCamera(gameState);
     this.gameBoard.innerHTML = '';
 

--- a/tests/domain/entities/DeletionEcho.test.js
+++ b/tests/domain/entities/DeletionEcho.test.js
@@ -142,4 +142,80 @@ describe('DeletionEcho', () => {
       expect(murmurs.size).toBeGreaterThan(1); // Should get different murmurs
     });
   });
+
+  describe('Dialogue System', () => {
+    test('should provide initial dialogue when not haunting', () => {
+      deletionEcho.haunting = false;
+      const dialogue = deletionEcho.getDialogue();
+
+      expect(dialogue).toContain('*A ghostly figure materializes from the canyon mist*');
+      expect(dialogue).toContain('I am the Echo... of all that was erased...');
+      expect(dialogue).toContain('*whispers* You seek the power of deletion?');
+    });
+
+    test('should guide player to learn x key when missing', () => {
+      deletionEcho.startHaunting();
+      const gameState = { collectedKeys: new Set() };
+      const dialogue = deletionEcho.getDialogue(gameState);
+
+      expect(dialogue).toContain('Begin with precision... single character death.');
+      expect(dialogue).toContain('x marks the spot... where text shall fall.');
+    });
+
+    test('should guide player to learn dd key when x is learned but dd is missing', () => {
+      deletionEcho.startHaunting();
+      const gameState = { collectedKeys: new Set(['x']) };
+      const dialogue = deletionEcho.getDialogue(gameState);
+
+      expect(dialogue).toContain('dd... the line destroyer... entire rows vanish.');
+      expect(dialogue).toContain('Find the power... to erase complete thoughts.');
+    });
+
+    test('should guide player to learn D key when x and dd are learned but D is missing', () => {
+      deletionEcho.startHaunting();
+      const gameState = { collectedKeys: new Set(['x', 'dd']) };
+      const dialogue = deletionEcho.getDialogue(gameState);
+
+      expect(dialogue).toContain('But what of... partial destruction?');
+      expect(dialogue).toContain("D takes all... from cursor to line's end.");
+      expect(dialogue).toContain('Seek the capital... in the deepest shadows.');
+    });
+
+    test('should guide player to learn dw key when x, dd, and D are learned but dw is missing', () => {
+      deletionEcho.startHaunting();
+      const gameState = { collectedKeys: new Set(['x', 'dd', 'D']) };
+      const dialogue = deletionEcho.getDialogue(gameState);
+
+      expect(dialogue).toContain('One power remains... word by word.');
+      expect(dialogue).toContain('dw... deletes entire words... thoughts disappear.');
+      expect(dialogue).toContain('Find this final piece... complete the destruction.');
+    });
+
+    test('should provide mastery dialogue when all deletion keys are learned', () => {
+      deletionEcho.startHaunting();
+      const gameState = { collectedKeys: new Set(['x', 'dd', 'D', 'dw']) };
+      const dialogue = deletionEcho.getDialogue(gameState);
+
+      expect(dialogue).toContain('You have mastered... the Four Deletions.');
+      expect(dialogue).toContain('x for precision, dd for lines, D for ends, dw for words.');
+      expect(dialogue).toContain('*nods approvingly* The canyon recognizes your power.');
+      expect(dialogue).toContain('But remember... *fading* ...with deletion comes responsibility.');
+    });
+
+    test('should handle missing gameState gracefully', () => {
+      deletionEcho.startHaunting();
+      const dialogue = deletionEcho.getDialogue();
+
+      // Should default to the !hasX branch
+      expect(dialogue).toContain('Begin with precision... single character death.');
+    });
+
+    test('should handle empty gameState gracefully', () => {
+      deletionEcho.startHaunting();
+      const dialogue = deletionEcho.getDialogue({});
+
+      // Should default to the !hasX branch
+      expect(dialogue).toContain('Begin with precision... single character death.');
+    });
+  });
 });

--- a/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
+++ b/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
@@ -90,12 +90,10 @@ describe('BlinkingGroveZone', () => {
       expect(config.tiles.hiddenAreas).toHaveLength(1);
       const hiddenArea = config.tiles.hiddenAreas[0];
       const hiddenCollectibleKeys = hiddenArea.specialTiles.filter(tile => tile.type === 'collectible_key');
-      expect(hiddenCollectibleKeys).toHaveLength(5);
+      expect(hiddenCollectibleKeys).toHaveLength(3);
 
-      // Verify the new keys exist in hidden area
+      // Verify the three keys for the gates exist in hidden area
       const keyIds = hiddenCollectibleKeys.map(key => key.keyId);
-      expect(keyIds).toContain('secret_vim_key');
-      expect(keyIds).toContain('master_key');
       expect(keyIds).toContain('golden_key');
       expect(keyIds).toContain('silver_key');
       expect(keyIds).toContain('bronze_key');

--- a/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
+++ b/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
@@ -75,15 +75,30 @@ describe('BlinkingGroveZone', () => {
     test('should have correct CollectibleKey configuration', () => {
       const config = BlinkingGroveZone.getConfig();
 
-      // Filter only CollectibleKeys
+      // Filter only CollectibleKeys from main area
       const collectibleKeys = config.tiles.specialTiles.filter(tile => tile.type === 'collectible_key');
-      expect(collectibleKeys).toHaveLength(1);
+      expect(collectibleKeys).toHaveLength(1); // Only main area maze key
 
+      // Check main area maze key
       const mazeKey = collectibleKeys[0];
       expect(mazeKey.keyId).toBe('maze_key');
       expect(mazeKey.name).toBe('Maze Key');
       expect(mazeKey.color).toBe('#FFD700');
       expect(mazeKey.position).toEqual([37, 14]);
+
+      // Check hidden area has the expected collectible keys
+      expect(config.tiles.hiddenAreas).toHaveLength(1);
+      const hiddenArea = config.tiles.hiddenAreas[0];
+      const hiddenCollectibleKeys = hiddenArea.specialTiles.filter(tile => tile.type === 'collectible_key');
+      expect(hiddenCollectibleKeys).toHaveLength(5);
+
+      // Verify the new keys exist in hidden area
+      const keyIds = hiddenCollectibleKeys.map(key => key.keyId);
+      expect(keyIds).toContain('secret_vim_key');
+      expect(keyIds).toContain('master_key');
+      expect(keyIds).toContain('golden_key');
+      expect(keyIds).toContain('silver_key');
+      expect(keyIds).toContain('bronze_key');
     });
 
     test('should have correct text labels configuration', () => {
@@ -103,21 +118,50 @@ describe('BlinkingGroveZone', () => {
       const config = BlinkingGroveZone.getConfig();
 
       expect(config.tiles.gate.locked).toBe(true);
-      expect(config.tiles.gate.position).toEqual([74, 1]); // Updated gate position
-      expect(config.tiles.gate.leadsTo).toBe('zone_2');
+      expect(config.tiles.gate.position).toEqual([74, 1]); // Gate position to connect with hidden area
+      expect(config.tiles.gate.leadsTo).toBe('vim_secret_area');
       expect(config.tiles.gate.unlocksWhen.collectedVimKeys).toEqual(['h', 'j', 'k', 'l']);
     });
 
     test('should have correct secondary gate configuration', () => {
       const config = BlinkingGroveZone.getConfig();
 
+      // Main area should only have the maze gate
       expect(config.tiles.secondaryGates).toBeDefined();
       expect(config.tiles.secondaryGates).toHaveLength(1);
 
-      const secondaryGate = config.tiles.secondaryGates[0];
-      expect(secondaryGate.locked).toBe(true);
-      expect(secondaryGate.position).toEqual([52, 3]);
-      expect(secondaryGate.unlocksWhen.requiredCollectibleKeys).toEqual(['maze_key']);
+      // Original maze gate
+      const mazeGate = config.tiles.secondaryGates[0];
+      expect(mazeGate.locked).toBe(true);
+      expect(mazeGate.position).toEqual([52, 3]);
+      expect(mazeGate.unlocksWhen.requiredCollectibleKeys).toEqual(['maze_key']);
+
+      // Check hidden area has the three new gates
+      expect(config.tiles.hiddenAreas).toHaveLength(1);
+      const hiddenArea = config.tiles.hiddenAreas[0];
+      expect(hiddenArea.secondaryGates).toBeDefined();
+      expect(hiddenArea.secondaryGates).toHaveLength(3);
+
+      // Golden gate
+      const goldenGate = hiddenArea.secondaryGates[0];
+      expect(goldenGate.locked).toBe(true);
+      expect(goldenGate.position).toEqual([34, 13]);
+      expect(goldenGate.unlocksWhen.requiredCollectibleKeys).toEqual(['golden_key']);
+      expect(goldenGate.leadsTo).toBe('golden_chamber');
+
+      // Silver gate
+      const silverGate = hiddenArea.secondaryGates[1];
+      expect(silverGate.locked).toBe(true);
+      expect(silverGate.position).toEqual([34, 14]);
+      expect(silverGate.unlocksWhen.requiredCollectibleKeys).toEqual(['silver_key']);
+      expect(silverGate.leadsTo).toBe('silver_chamber');
+
+      // Bronze gate
+      const bronzeGate = hiddenArea.secondaryGates[2];
+      expect(bronzeGate.locked).toBe(true);
+      expect(bronzeGate.position).toEqual([34, 15]);
+      expect(bronzeGate.unlocksWhen.requiredCollectibleKeys).toEqual(['bronze_key']);
+      expect(bronzeGate.leadsTo).toBe('bronze_chamber');
     });
 
     test('should have correct NPC configuration', () => {

--- a/tests/integration/blinkingGroveGame.test.js
+++ b/tests/integration/blinkingGroveGame.test.js
@@ -610,13 +610,23 @@ describe('Blinking Grove Game Integration', () => {
           }
         }
 
-                // Interact with gate to reveal hidden area (simulate 'x' key press)
+                // Interact with gate to reveal hidden area (simulate ESC key press exactly like real game)
         if (mainGate.leadsTo === 'vim_secret_area') {
-          // This should trigger hidden area reveal using the correct trigger
+          // Step 1: Reveal the hidden area (exactly like real game)
           const revealed = game.gameState.zone.revealHiddenArea('escProgression');
           expect(revealed).toBe(true);
+          
+          // Step 2: Enter the hidden area (exactly like real game)
+          const hiddenArea = game.gameState.zone.enterHiddenArea('vim_secret_area');
+          expect(hiddenArea).toBeTruthy();
+          expect(hiddenArea.id).toBe('vim_secret_area');
+          
+          // Step 3: Move player to hidden area start position (exactly like real game)
+          const startPos = game.gameState.zone.getHiddenAreaStartPosition('vim_secret_area');
+          expect(startPos).toBeTruthy();
+          game.gameState.cursor = game.gameState.cursor.moveTo(startPos);
         }
-        
+
         // Get updated state after hidden area reveal
         const updatedState = game.gameState.getCurrentState();
 
@@ -631,27 +641,27 @@ describe('Blinking Grove Game Integration', () => {
         for (const testKey of hiddenAreaKeys) {
           // Move cursor to key position
           game.gameState.cursor = game.gameState.cursor.moveTo(testKey.position);
-          
+
           // Check if cursor position exactly matches key position
           expect(game.gameState.cursor.position.equals(testKey.position)).toBe(true);
-          
+
           // Try to collect the key using the same logic as MovePlayerUseCase
           const currentState = game.gameState.getCurrentState();
           const collectibleKeyAtPosition = currentState.availableCollectibleKeys.find((key) =>
             key.position.equals(game.gameState.cursor.position)
           );
-          
+
           // Key should be found at cursor position
           expect(collectibleKeyAtPosition).toBeTruthy();
           expect(collectibleKeyAtPosition.keyId).toBe(testKey.keyId);
-          
+
           // Collect the key
           game.gameState.collectCollectibleKey(collectibleKeyAtPosition);
-          
+
           // Verify collection worked
           const stateAfterCollection = game.gameState.getCurrentState();
           expect(stateAfterCollection.collectedCollectibleKeys.has(testKey.keyId)).toBe(true);
-          
+
           // Verify key is removed from available keys
           const remainingKeys = stateAfterCollection.availableCollectibleKeys.find(
             k => k.keyId === testKey.keyId

--- a/tests/integration/blinkingGroveGame.test.js
+++ b/tests/integration/blinkingGroveGame.test.js
@@ -615,12 +615,12 @@ describe('Blinking Grove Game Integration', () => {
           // Step 1: Reveal the hidden area (exactly like real game)
           const revealed = game.gameState.zone.revealHiddenArea('escProgression');
           expect(revealed).toBe(true);
-          
+
           // Step 2: Enter the hidden area (exactly like real game)
           const hiddenArea = game.gameState.zone.enterHiddenArea('vim_secret_area');
           expect(hiddenArea).toBeTruthy();
           expect(hiddenArea.id).toBe('vim_secret_area');
-          
+
           // Step 3: Move player to hidden area start position (exactly like real game)
           const startPos = game.gameState.zone.getHiddenAreaStartPosition('vim_secret_area');
           expect(startPos).toBeTruthy();

--- a/tests/integration/game.test.js
+++ b/tests/integration/game.test.js
@@ -363,4 +363,60 @@ describe('VIM for Kids Game Integration', () => {
       }).toThrow();
     });
   });
+
+  describe('ESC Key Handling', () => {
+    it('should handle ESC key when game state is null', async () => {
+      game = new VimForKidsGame();
+      game.gameState = null;
+
+      // Should not throw when gameState is null
+      await expect(game._handleEscKeyPressed()).resolves.toBeUndefined();
+    });
+
+    it('should handle ESC key when current state is null', async () => {
+      game = new VimForKidsGame();
+      jest.spyOn(game.gameState, 'getCurrentState').mockReturnValue(null);
+
+      // Should not throw when current state is null
+      await expect(game._handleEscKeyPressed()).resolves.toBeUndefined();
+    });
+
+    it('should handle ESC key when current zone is null', async () => {
+      game = new VimForKidsGame();
+      const mockState = { currentZone: null, cursor: { position: new Position(1, 1) } };
+      jest.spyOn(game.gameState, 'getCurrentState').mockReturnValue(mockState);
+
+      // Should not throw when current zone is null
+      await expect(game._handleEscKeyPressed()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Level Cutscene Handling', () => {
+    it('should handle missing levelId gracefully', async () => {
+      game = new VimForKidsGame();
+
+      // Should return early when no levelId provided
+      await expect(game._showLevelCutsceneIfNeeded('gameId', null)).resolves.toBeUndefined();
+    });
+
+    it('should handle cutscene service being null gracefully', async () => {
+      game = new VimForKidsGame();
+
+      // Cutscene service might be null in some configurations
+      expect(game.cutsceneService).toBeNull();
+
+      // Should not throw when cutscene service is null
+      await expect(game._showLevelCutsceneIfNeeded('gameId', 'levelId')).resolves.toBeUndefined();
+    });
+
+    it('should handle method calls when dependencies are null', async () => {
+      game = new VimForKidsGame();
+
+      // Should handle null services gracefully
+      expect(() => {
+        // These methods should handle null dependencies without throwing
+        game._handleEscKeyPressed();
+      }).not.toThrow();
+    });
+  });
 });

--- a/tests/integration/levelTransition.test.js
+++ b/tests/integration/levelTransition.test.js
@@ -114,8 +114,12 @@ describe('Level Transition Integration', () => {
       // For zone_1, ESC progression must be marked as pressed
       game.gameState.markEscProgressionPressed();
 
-      // Should be ready for level progression
-      expect(game.gameState.shouldProgressToNextLevel()).toBe(true);
+      // In zone_1, the gate leads to a hidden area, so shouldProgressToNextLevel returns false
+      // This is expected behavior - hidden areas prevent direct level progression
+      expect(game.gameState.shouldProgressToNextLevel()).toBe(false);
+
+      // Verify the gate leads to the hidden area as expected
+      expect(gate.leadsTo).toBe('vim_secret_area');
 
       // Test the transitionToLevel method directly
       await game.transitionToLevel('level_2');

--- a/tests/integration/zoneProgression.test.js
+++ b/tests/integration/zoneProgression.test.js
@@ -97,8 +97,12 @@ describe('Zone and Level Progression Integration', () => {
       // For zone_1, ESC progression must be marked as pressed
       game.gameState.markEscProgressionPressed();
 
-      // Should trigger progression to next level
-      expect(game.gameState.shouldProgressToNextLevel()).toBe(true);
+      // In zone_1, the gate leads to a hidden area, so shouldProgressToNextLevel returns false
+      // This is expected behavior - hidden areas prevent direct level progression
+      expect(game.gameState.shouldProgressToNextLevel()).toBe(false);
+
+      // Verify the gate leads to the hidden area as expected
+      expect(gate.leadsTo).toBe('vim_secret_area');
     });
   });
 


### PR DESCRIPTION
Enhanced the BlinkingGroveZone hidden area with significant gameplay and narrative improvements:

**New Features:**
- Added 3 new collectible keys (golden, silver, bronze) positioned near the "vim Total Rulez!!!" text
- Added 3 corresponding gates that unlock with specific keys and lead to themed chambers
- Completed the hidden area story/poem with missing text lines to form a complete narrative

**Bug Fixes:**
- Fixed hidden area offset issues where NPCs would shift position when hidden areas appeared
- Resolved camera positioning problems by using original zone boundaries for content bounds calculation
- Fixed collectible key visibility issues by implementing live zone data instead of cached state
- Prevented array overwrites during hidden area revelation by modifying initialization logic

**Technical Improvements:**
- Enhanced Zone entity to properly handle hidden area secondary gates during revelation
- Modified game state to always use fresh collectible keys from zones instead of stale cached data
- Updated rendering logic to maintain consistent NPC and camera positioning
- Improved state management for dynamic content in hidden areas

This enhancement creates a more engaging hidden area experience with meaningful rewards and a complete narrative while maintaining stable gameplay mechanics.
