### PR TITLE
feat: Canvas-based game renderer with rAF game loop (P0)

### DIFF
--- a/src/infrastructure/FeatureFlags.js
+++ b/src/infrastructure/FeatureFlags.js
@@ -28,6 +28,7 @@ class FeatureFlags {
       TUTORIAL_MODE: true,
       ACHIEVEMENT_SYSTEM: false,
       ENHANCED_3D_EFFECTS: true, // Toggle for pseudo-3D tile enhancements
+      CANVAS_RENDERER: false, // Toggle for Canvas-based game rendering
 
       // Load flags from environment or remote config
       ...this.loadFromEnvironment(),

--- a/src/infrastructure/rendering/AssetLoader.js
+++ b/src/infrastructure/rendering/AssetLoader.js
@@ -1,0 +1,43 @@
+/**
+ * Promise-based asset loader for images and other resources.
+ * Loads assets in parallel and provides named access once loaded.
+ */
+export class AssetLoader {
+  constructor() {
+    this._assets = new Map();
+    this._loaded = false;
+  }
+
+  get isLoaded() {
+    return this._loaded;
+  }
+
+  loadImage(url) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error(`Failed to load image: ${url}`));
+      img.src = url;
+    });
+  }
+
+  async loadAll(manifest) {
+    const entries = Object.entries(manifest);
+    const results = await Promise.all(
+      entries.map(async ([name, url]) => {
+        const asset = await this.loadImage(url);
+        return [name, asset];
+      })
+    );
+
+    for (const [name, asset] of results) {
+      this._assets.set(name, asset);
+    }
+
+    this._loaded = true;
+  }
+
+  getAsset(name) {
+    return this._assets.get(name) || null;
+  }
+}

--- a/src/infrastructure/rendering/Camera.js
+++ b/src/infrastructure/rendering/Camera.js
@@ -1,0 +1,167 @@
+/**
+ * Camera system for viewport management and smooth scrolling.
+ * Pure math — no DOM dependency. Extracted from DOMGameRenderer camera logic.
+ */
+export class Camera {
+  constructor(tileSize = 32) {
+    this._tileSize = tileSize;
+    this._x = 0;
+    this._y = 0;
+    this._targetX = 0;
+    this._targetY = 0;
+    this._viewportWidth = 15;
+    this._viewportHeight = 10;
+    this._scrollThreshold = 0.7;
+    this._smoothingFactor = 0.15;
+    this._isInitialized = false;
+    this._lastCursorKey = null;
+  }
+
+  get x() {
+    return this._x;
+  }
+
+  get y() {
+    return this._y;
+  }
+
+  get viewportWidth() {
+    return this._viewportWidth;
+  }
+
+  get viewportHeight() {
+    return this._viewportHeight;
+  }
+
+  get tileSize() {
+    return this._tileSize;
+  }
+
+  get isInitialized() {
+    return this._isInitialized;
+  }
+
+  setViewportSize(screenWidth, screenHeight, uiOffset = 120) {
+    const usableHeight = screenHeight - uiOffset;
+    this._viewportWidth = Math.max(Math.floor(screenWidth / this._tileSize), 15);
+    this._viewportHeight = Math.max(Math.floor(usableHeight / this._tileSize), 10);
+  }
+
+  update(cursorPosition, mapBounds, zoneBounds = null) {
+    const cursorKey = `${cursorPosition.x},${cursorPosition.y}`;
+
+    if (this._shouldCenterOnZone(cursorKey, cursorPosition)) {
+      this._centerOnZone(cursorPosition, mapBounds, zoneBounds);
+      this._lastCursorKey = cursorKey;
+      return true;
+    }
+
+    if (this._lastCursorKey !== cursorKey) {
+      this._updateScrolling(cursorPosition, mapBounds);
+      this._lastCursorKey = cursorKey;
+    }
+    return false;
+  }
+
+  interpolate() {
+    const dx = this._targetX - this._x;
+    const dy = this._targetY - this._y;
+
+    if (Math.abs(dx) < 0.1 && Math.abs(dy) < 0.1) {
+      this._x = this._targetX;
+      this._y = this._targetY;
+      return false; // no movement
+    }
+
+    this._x += dx * this._smoothingFactor;
+    this._y += dy * this._smoothingFactor;
+    return true; // still moving
+  }
+
+  getVisibleBounds() {
+    const startX = Math.floor(this._x);
+    const startY = Math.floor(this._y);
+    return {
+      startX,
+      startY,
+      endX: startX + this._viewportWidth,
+      endY: startY + this._viewportHeight,
+    };
+  }
+
+  worldToScreen(worldX, worldY) {
+    return {
+      x: (worldX - this._x) * this._tileSize,
+      y: (worldY - this._y) * this._tileSize,
+    };
+  }
+
+  reset() {
+    this._x = 0;
+    this._y = 0;
+    this._targetX = 0;
+    this._targetY = 0;
+    this._isInitialized = false;
+    this._lastCursorKey = null;
+  }
+
+  _shouldCenterOnZone(cursorKey, cursorPosition) {
+    if (!this._isInitialized) return true;
+    if (this._lastCursorKey === cursorKey) return false;
+
+    const prev = this._lastCursorKey ? this._lastCursorKey.split(',').map(Number) : [0, 0];
+    const manhattan = Math.abs(cursorPosition.x - prev[0]) + Math.abs(cursorPosition.y - prev[1]);
+    return manhattan > 5;
+  }
+
+  _centerOnZone(cursorPosition, mapBounds, zoneBounds) {
+    const centerX = Math.floor(this._viewportWidth / 2);
+    const centerY = Math.floor(this._viewportHeight / 2);
+
+    let targetX;
+    if (zoneBounds) {
+      targetX = zoneBounds.minX - centerX;
+    } else {
+      targetX = cursorPosition.x - centerX;
+    }
+
+    const targetY = Math.max(
+      0,
+      Math.min(cursorPosition.y - centerY, mapBounds.height - this._viewportHeight)
+    );
+
+    this._x = targetX;
+    this._y = targetY;
+    this._targetX = targetX;
+    this._targetY = targetY;
+    this._isInitialized = true;
+  }
+
+  _updateScrolling(cursorPosition, mapBounds) {
+    const centerX = Math.floor(this._viewportWidth / 2);
+    const centerY = Math.floor(this._viewportHeight / 2);
+    const threshX = Math.floor(this._viewportWidth * this._scrollThreshold);
+    const threshY = Math.floor(this._viewportHeight * this._scrollThreshold);
+
+    const cursorViewX = cursorPosition.x - this._x;
+    const cursorViewY = cursorPosition.y - this._y;
+
+    let newTargetX = this._targetX;
+    let newTargetY = this._targetY;
+
+    if (cursorViewX >= threshX) {
+      newTargetX = cursorPosition.x - threshX;
+    } else if (cursorViewX <= this._viewportWidth - threshX) {
+      newTargetX = cursorPosition.x - (this._viewportWidth - threshX);
+    }
+
+    if (cursorViewY >= threshY) {
+      newTargetY = cursorPosition.y - threshY;
+    } else if (cursorViewY <= this._viewportHeight - threshY) {
+      newTargetY = cursorPosition.y - (this._viewportHeight - threshY);
+    }
+
+    this._targetX = Math.min(newTargetX, mapBounds.width - this._viewportWidth);
+    this._targetY = Math.max(0, Math.min(newTargetY, mapBounds.height - this._viewportHeight));
+  }
+}

--- a/src/infrastructure/rendering/EntityIndex.js
+++ b/src/infrastructure/rendering/EntityIndex.js
@@ -1,0 +1,95 @@
+/**
+ * Spatial index for O(1) entity lookups by position.
+ * Replaces per-tile .find() linear scans in the render loop.
+ */
+export class EntityIndex {
+  constructor() {
+    this._keys = new Map();
+    this._collectibles = new Map();
+    this._npcs = new Map();
+    this._textLabels = new Map();
+    this._gate = null;
+    this._gateKey = null;
+    this._secondaryGates = new Map();
+  }
+
+  rebuild(gameState) {
+    this._keys.clear();
+    this._collectibles.clear();
+    this._npcs.clear();
+    this._textLabels.clear();
+    this._secondaryGates.clear();
+    this._gate = null;
+    this._gateKey = null;
+
+    if (gameState.availableKeys) {
+      for (const key of gameState.availableKeys) {
+        this._keys.set(this._posKey(key.position.x, key.position.y), key);
+      }
+    }
+
+    if (gameState.availableCollectibleKeys) {
+      for (const ck of gameState.availableCollectibleKeys) {
+        this._collectibles.set(this._posKey(ck.position.x, ck.position.y), ck);
+      }
+    }
+
+    if (gameState.npcs) {
+      for (const npc of gameState.npcs) {
+        if (npc.position && Array.isArray(npc.position)) {
+          this._npcs.set(this._posKey(npc.position[0], npc.position[1]), npc);
+        }
+      }
+    }
+
+    if (gameState.textLabels) {
+      for (const label of gameState.textLabels) {
+        this._textLabels.set(this._posKey(label.position.x, label.position.y), label);
+      }
+    }
+
+    if (gameState.gate) {
+      this._gate = gameState.gate;
+      this._gateKey = this._posKey(gameState.gate.position.x, gameState.gate.position.y);
+    }
+
+    if (gameState.secondaryGates) {
+      for (const sg of gameState.secondaryGates) {
+        if (!sg.isOpen) {
+          this._secondaryGates.set(this._posKey(sg.position.x, sg.position.y), sg);
+        }
+      }
+    }
+  }
+
+  getKeyAt(x, y) {
+    return this._keys.get(this._posKey(x, y)) || null;
+  }
+
+  getCollectibleAt(x, y) {
+    return this._collectibles.get(this._posKey(x, y)) || null;
+  }
+
+  getNPCAt(x, y) {
+    return this._npcs.get(this._posKey(x, y)) || null;
+  }
+
+  getTextLabelAt(x, y) {
+    return this._textLabels.get(this._posKey(x, y)) || null;
+  }
+
+  getGateAt(x, y) {
+    if (this._gate && this._gateKey === this._posKey(x, y)) {
+      return this._gate;
+    }
+    return null;
+  }
+
+  getSecondaryGateAt(x, y) {
+    return this._secondaryGates.get(this._posKey(x, y)) || null;
+  }
+
+  _posKey(x, y) {
+    return `${x},${y}`;
+  }
+}

--- a/src/infrastructure/rendering/GameLoop.js
+++ b/src/infrastructure/rendering/GameLoop.js
@@ -1,0 +1,69 @@
+/**
+ * Game loop using requestAnimationFrame for smooth 60fps rendering.
+ * Calculates deltaTime between frames and invokes update/draw callbacks.
+ */
+export class GameLoop {
+  constructor(updateFn, drawFn) {
+    if (typeof updateFn !== 'function') {
+      throw new Error('updateFn must be a function');
+    }
+    if (typeof drawFn !== 'function') {
+      throw new Error('drawFn must be a function');
+    }
+
+    this._updateFn = updateFn;
+    this._drawFn = drawFn;
+    this._animationFrameId = null;
+    this._lastTimestamp = null;
+    this._running = false;
+    this._needsRedraw = true;
+
+    this._tick = this._tick.bind(this);
+  }
+
+  get isRunning() {
+    return this._running;
+  }
+
+  start() {
+    if (this._running) return;
+
+    this._running = true;
+    this._lastTimestamp = null;
+    this._animationFrameId = requestAnimationFrame(this._tick);
+  }
+
+  stop() {
+    if (!this._running) return;
+
+    this._running = false;
+    if (this._animationFrameId !== null) {
+      cancelAnimationFrame(this._animationFrameId);
+      this._animationFrameId = null;
+    }
+    this._lastTimestamp = null;
+  }
+
+  requestRedraw() {
+    this._needsRedraw = true;
+  }
+
+  _tick(timestamp) {
+    if (!this._running) return;
+
+    const deltaTime = this._lastTimestamp !== null ? (timestamp - this._lastTimestamp) / 1000 : 0;
+    this._lastTimestamp = timestamp;
+
+    // Cap deltaTime to prevent spiral of death after tab switch
+    const cappedDeltaTime = Math.min(deltaTime, 0.1);
+
+    this._updateFn(cappedDeltaTime);
+
+    if (this._needsRedraw) {
+      this._drawFn(cappedDeltaTime);
+      this._needsRedraw = false;
+    }
+
+    this._animationFrameId = requestAnimationFrame(this._tick);
+  }
+}

--- a/src/infrastructure/rendering/SpriteSheet.js
+++ b/src/infrastructure/rendering/SpriteSheet.js
@@ -1,0 +1,51 @@
+/**
+ * Wraps a loaded Image and provides frame extraction by index.
+ * Sprite sheets are organized as a grid of equal-sized tiles.
+ */
+export class SpriteSheet {
+  constructor(image, tileWidth, tileHeight, columns) {
+    if (!image) {
+      throw new Error('SpriteSheet requires a valid image');
+    }
+    if (tileWidth <= 0 || tileHeight <= 0) {
+      throw new Error('Tile dimensions must be positive');
+    }
+    if (columns <= 0) {
+      throw new Error('Columns must be positive');
+    }
+
+    this._image = image;
+    this._tileWidth = tileWidth;
+    this._tileHeight = tileHeight;
+    this._columns = columns;
+  }
+
+  get image() {
+    return this._image;
+  }
+
+  get tileWidth() {
+    return this._tileWidth;
+  }
+
+  get tileHeight() {
+    return this._tileHeight;
+  }
+
+  getFrame(index) {
+    if (index < 0) {
+      throw new Error('Frame index must be non-negative');
+    }
+
+    const col = index % this._columns;
+    const row = Math.floor(index / this._columns);
+
+    return {
+      image: this._image,
+      sx: col * this._tileWidth,
+      sy: row * this._tileHeight,
+      sw: this._tileWidth,
+      sh: this._tileHeight,
+    };
+  }
+}

--- a/src/infrastructure/ui/CanvasGameRenderer.js
+++ b/src/infrastructure/ui/CanvasGameRenderer.js
@@ -1,0 +1,522 @@
+import { GameRenderer } from '../../ports/output/GameRenderer.js';
+import { Camera } from '../rendering/Camera.js';
+import { GameLoop } from '../rendering/GameLoop.js';
+import { EntityIndex } from '../rendering/EntityIndex.js';
+
+/**
+ * Canvas-based game renderer implementing the GameRenderer port.
+ * Uses HTML5 Canvas for tile rendering with a rAF game loop.
+ * DOM overlays handle UI chrome (messages, balloons, keys display).
+ */
+export class CanvasGameRenderer extends GameRenderer {
+  constructor() {
+    super();
+
+    this._camera = new Camera(32);
+    this._entityIndex = new EntityIndex();
+    this._currentGameState = null;
+    this._previousCursorKey = null;
+    this._previousCollectedCount = 0;
+
+    // DOM elements
+    this._container = document.getElementById('game-container');
+    this.gameBoard = this._createCanvas();
+    this._collectedKeysDisplay = document.querySelector('.key-display');
+    this._collectibleInventoryDisplay = document.querySelector('.collectible-display');
+
+    // Initialize viewport
+    this._camera.setViewportSize(window.innerWidth, window.innerHeight);
+    this._resizeCanvas();
+
+    window.addEventListener('resize', () => {
+      this._camera.setViewportSize(window.innerWidth, window.innerHeight);
+      this._resizeCanvas();
+      this._gameLoop.requestRedraw();
+    });
+
+    // Canvas 2D context
+    this._ctx = this.gameBoard.getContext('2d');
+
+    // Game loop
+    this._gameLoop = new GameLoop(
+      (dt) => this._update(dt),
+      (dt) => this._draw(dt)
+    );
+    this._gameLoop.start();
+
+    // Message state
+    this._currentMessage = null;
+    this._messageTimeout = null;
+
+    // Tile color map for colored-rectangle rendering (P0 placeholder)
+    this._tileColors = {
+      water: '#2980b9',
+      grass: '#27ae60',
+      dirt: '#d2b48c',
+      tree: '#228b22',
+      stone: '#b8b8aa',
+      path: '#f4d03f',
+      wall: '#566573',
+      bridge: '#8b4513',
+      sand: '#f4d03f',
+      ruins: '#85929e',
+      field: '#58d68d',
+      test_ground: '#bb8fce',
+      void: '#1a1a1a',
+      boss_area: '#e74c3c',
+      ramp_right: '#8b9dc3',
+      ramp_left: '#8b9dc3',
+    };
+  }
+
+  _createCanvas() {
+    const canvas = document.createElement('canvas');
+    canvas.id = 'gameBoardCanvas';
+    canvas.className = 'game-board-canvas';
+    canvas.setAttribute('tabindex', '0');
+
+    // Insert canvas into game container (alongside existing gameBoard div)
+    const existingBoard = document.getElementById('gameBoard');
+    if (existingBoard) {
+      existingBoard.style.display = 'none';
+      existingBoard.parentNode.insertBefore(canvas, existingBoard);
+    } else if (this._container) {
+      this._container.appendChild(canvas);
+    }
+
+    return canvas;
+  }
+
+  _resizeCanvas() {
+    const w = this._camera.viewportWidth * this._camera.tileSize;
+    const h = this._camera.viewportHeight * this._camera.tileSize;
+    this.gameBoard.width = w;
+    this.gameBoard.height = h;
+    this.gameBoard.style.width = `${w}px`;
+    this.gameBoard.style.height = `${h}px`;
+  }
+
+  // --- GameRenderer port methods ---
+
+  render(gameState) {
+    this._currentGameState = gameState;
+    this._entityIndex.rebuild(gameState);
+
+    // Update camera
+    const mapBounds = {
+      width: gameState.map.width || gameState.map.size,
+      height: gameState.map.height || gameState.map.size,
+    };
+    this._camera.update(gameState.cursor.position, mapBounds);
+
+    // Request redraw
+    this._gameLoop.requestRedraw();
+
+    // Update UI overlays
+    this.updateCollectedKeysDisplay(gameState.collectedKeys);
+    this.updateCollectibleInventoryDisplay(gameState.collectedCollectibleKeys || new Set());
+  }
+
+  updateCollectedKeysDisplay(collectedKeys) {
+    if (!this._collectedKeysDisplay) return;
+    this._collectedKeysDisplay.innerHTML = '';
+
+    if (collectedKeys.size === 0) {
+      const empty = document.createElement('div');
+      empty.textContent = 'No keys collected yet!';
+      empty.style.color = '#95a5a6';
+      empty.style.fontStyle = 'italic';
+      this._collectedKeysDisplay.appendChild(empty);
+    } else {
+      collectedKeys.forEach((keyName) => {
+        const el = document.createElement('div');
+        el.className = 'collected-key';
+        el.textContent = keyName;
+        this._collectedKeysDisplay.appendChild(el);
+      });
+    }
+  }
+
+  updateCollectibleInventoryDisplay(collectedCollectibleKeys) {
+    if (!this._collectibleInventoryDisplay) return;
+    this._collectibleInventoryDisplay.innerHTML = '';
+
+    if (collectedCollectibleKeys.size === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'collectible-empty-message';
+      empty.textContent = 'No special keys found yet!';
+      this._collectibleInventoryDisplay.appendChild(empty);
+    } else {
+      collectedCollectibleKeys.forEach((keyId) => {
+        const el = document.createElement('div');
+        el.className = 'collected-collectible-key';
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'collectible-key-name';
+        nameSpan.textContent = this._formatKeyName(keyId);
+        el.appendChild(nameSpan);
+        el.title = `Collected: ${this._formatKeyName(keyId)}`;
+        this._collectibleInventoryDisplay.appendChild(el);
+      });
+    }
+  }
+
+  showKeyInfo(key) {
+    if (key && key.type === 'collectible_key') {
+      this._showCollectibleKeyFeedback(key);
+    }
+  }
+
+  showMessage(message, options = {}) {
+    const { duration = 4000, position = 'center', type = 'info', speaker = null } = options;
+    this.hideMessage();
+
+    const el = document.createElement('div');
+    el.className = `message-bubble ${type}`;
+    el.setAttribute('data-position', position);
+
+    if (speaker) {
+      const speakerEl = document.createElement('div');
+      speakerEl.className = 'message-speaker';
+      speakerEl.textContent = speaker;
+      el.appendChild(speakerEl);
+    }
+
+    const textEl = document.createElement('div');
+    textEl.className = 'message-text';
+    textEl.textContent = message;
+    el.appendChild(textEl);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'message-close';
+    closeBtn.innerHTML = '&times;';
+    closeBtn.onclick = () => this.hideMessage();
+    el.appendChild(closeBtn);
+
+    const container = this._container || document.body;
+    container.appendChild(el);
+    this._currentMessage = el;
+
+    if (duration > 0) {
+      this._messageTimeout = setTimeout(() => this.hideMessage(), duration);
+    }
+
+    return el;
+  }
+
+  hideMessage() {
+    if (this._currentMessage) {
+      this._currentMessage.remove();
+      this._currentMessage = null;
+    }
+    if (this._messageTimeout) {
+      clearTimeout(this._messageTimeout);
+      this._messageTimeout = null;
+    }
+  }
+
+  // --- Additional methods used by application code ---
+
+  focus() {
+    this.gameBoard.focus();
+  }
+
+  resetCamera() {
+    this._camera.reset();
+  }
+
+  showNPCDialogue(npc, dialogue, options = {}) {
+    const text = Array.isArray(dialogue) ? dialogue.join(' ') : String(dialogue);
+    return this.showNPCBalloon(npc, text, options);
+  }
+
+  showNPCBalloon(npc, message, options = {}) {
+    const { duration = 4000 } = options;
+    this.fadeOutExistingBalloons();
+
+    const balloon = document.createElement('div');
+    balloon.className = 'npc-balloon';
+    balloon.textContent = message;
+
+    // Position balloon relative to container
+    const container = this._container || document.body;
+    container.appendChild(balloon);
+
+    // Try to position above the NPC using canvas coordinates
+    if (this._currentGameState && npc) {
+      const npcPos = this._findNPCScreenPosition(npc);
+      if (npcPos) {
+        const canvasRect = this.gameBoard.getBoundingClientRect();
+        const containerRect = container.getBoundingClientRect();
+        const balloonX = canvasRect.left - containerRect.left + npcPos.x + this._camera.tileSize / 2;
+        const balloonY = canvasRect.top - containerRect.top + npcPos.y - 60;
+
+        balloon.style.left = `${balloonX}px`;
+        balloon.style.top = `${Math.max(balloonY, 10)}px`;
+        balloon.style.transform = 'translateX(-50%)';
+        balloon.style.position = 'absolute';
+      }
+    }
+
+    if (duration > 0) {
+      setTimeout(() => {
+        if (balloon.parentNode) balloon.remove();
+      }, duration);
+    }
+
+    return balloon;
+  }
+
+  fadeOutExistingBalloons() {
+    const container = this._container || document.body;
+    const balloons = container.querySelectorAll('.npc-balloon');
+    balloons.forEach((b) => {
+      if (!b.classList.contains('fade-out')) {
+        b.classList.add('fade-out');
+        setTimeout(() => {
+          if (b.parentNode) b.remove();
+        }, 300);
+      }
+    });
+  }
+
+  showNPCMessage(message, options = {}) {
+    const { duration = 4000, position = 'center', type = 'info', speaker = null } = options;
+    this.hideMessage();
+
+    const el = document.createElement('div');
+    el.className = `message-bubble ${type}`;
+    el.setAttribute('data-position', position);
+
+    if (speaker) {
+      const speakerEl = document.createElement('div');
+      speakerEl.className = 'message-speaker';
+      speakerEl.textContent = speaker;
+      el.appendChild(speakerEl);
+    }
+
+    const textEl = document.createElement('div');
+    textEl.className = 'message-text';
+    textEl.textContent = message;
+    el.appendChild(textEl);
+
+    const container = this._container || document.body;
+    container.appendChild(el);
+    this._currentMessage = el;
+
+    if (duration > 0) {
+      this._messageTimeout = setTimeout(() => this.hideMessage(), duration);
+    }
+
+    return el;
+  }
+
+  cleanup() {
+    this._gameLoop.stop();
+    window.removeEventListener('resize', this._resizeHandler);
+    if (this.gameBoard && this.gameBoard.parentNode) {
+      this.gameBoard.parentNode.removeChild(this.gameBoard);
+    }
+  }
+
+  // --- Private: Game loop callbacks ---
+
+  _update(_deltaTime) {
+    // Interpolate camera for smooth scrolling
+    if (this._camera.interpolate()) {
+      this._gameLoop.requestRedraw();
+    }
+  }
+
+  _draw(_deltaTime) {
+    if (!this._currentGameState) return;
+
+    const ctx = this._ctx;
+    const ts = this._camera.tileSize;
+    const bounds = this._camera.getVisibleBounds();
+    const gameState = this._currentGameState;
+    const map = gameState.map;
+    const mapWidth = map.width || map.size;
+    const mapHeight = map.height || map.size;
+
+    // Clear
+    ctx.clearRect(0, 0, this.gameBoard.width, this.gameBoard.height);
+
+    // Draw tiles
+    for (let row = bounds.startY; row < bounds.endY; row++) {
+      for (let col = bounds.startX; col < bounds.endX; col++) {
+        const screenX = (col - bounds.startX) * ts;
+        const screenY = (row - bounds.startY) * ts;
+
+        // Determine tile type
+        let tileName = 'water';
+        if (col >= 0 && col < mapWidth && row >= 0 && row < mapHeight) {
+          const pos = { x: col, y: row, equals: () => false };
+          // Use getTileAt with a minimal position-like object
+          try {
+            const tileType = map.getTileAt(
+              new (Object.getPrototypeOf(gameState.cursor.position).constructor)(col, row)
+            );
+            tileName = tileType.name;
+          } catch {
+            tileName = 'water';
+          }
+        }
+
+        // Draw tile rectangle
+        ctx.fillStyle = this._tileColors[tileName] || '#3498db';
+        ctx.fillRect(screenX, screenY, ts, ts);
+
+        // Draw entities at this position
+        this._drawEntitiesAt(ctx, col, row, screenX, screenY, ts);
+      }
+    }
+
+    // Draw cursor on top
+    this._drawCursor(ctx, gameState.cursor, bounds, ts);
+  }
+
+  _drawEntitiesAt(ctx, worldX, worldY, screenX, screenY, ts) {
+    const half = ts / 2;
+
+    // VIM Key
+    const key = this._entityIndex.getKeyAt(worldX, worldY);
+    if (key) {
+      ctx.fillStyle = '#e74c3c';
+      ctx.font = 'bold 14px "Courier New", monospace';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(key.key, screenX + half, screenY + half);
+    }
+
+    // Collectible Key
+    const ck = this._entityIndex.getCollectibleAt(worldX, worldY);
+    if (ck) {
+      ctx.fillStyle = ck.color || '#FFD700';
+      ctx.font = '18px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('\uD83D\uDD11', screenX + half, screenY + half);
+    }
+
+    // Gate
+    const gate = this._entityIndex.getGateAt(worldX, worldY);
+    if (gate) {
+      ctx.fillStyle = gate.isOpen ? '#27ae60' : '#e74c3c';
+      ctx.fillRect(screenX + 4, screenY + 4, ts - 8, ts - 8);
+      ctx.font = '16px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(gate.isOpen ? '\uD83D\uDEAA' : '\uD83D\uDEA7', screenX + half, screenY + half);
+    }
+
+    // Secondary Gate
+    const sg = this._entityIndex.getSecondaryGateAt(worldX, worldY);
+    if (sg) {
+      ctx.fillStyle = '#8B4513';
+      ctx.fillRect(screenX + 2, screenY + 2, ts - 4, ts - 4);
+      // Door knob
+      ctx.fillStyle = '#FFD700';
+      ctx.beginPath();
+      ctx.arc(screenX + ts * 0.75, screenY + half, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Text Label
+    const label = this._entityIndex.getTextLabelAt(worldX, worldY);
+    if (label) {
+      ctx.fillStyle = label.color || '#2c3e50';
+      ctx.font = `${label.fontWeight || 'bold'} ${label.fontSize || '10px'} "Courier New", monospace`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(label.text, screenX + half, screenY + ts - 2);
+    }
+
+    // NPC
+    const npc = this._entityIndex.getNPCAt(worldX, worldY);
+    if (npc) {
+      const symbol =
+        npc.getVisualSymbol && typeof npc.getVisualSymbol === 'function'
+          ? npc.getVisualSymbol()
+          : this._getNpcFallbackSymbol(npc);
+      ctx.font = '16px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(symbol, screenX + half, screenY + half);
+    }
+  }
+
+  _drawCursor(ctx, cursor, bounds, ts) {
+    const cx = cursor.position.x;
+    const cy = cursor.position.y;
+
+    if (cx >= bounds.startX && cx < bounds.endX && cy >= bounds.startY && cy < bounds.endY) {
+      const screenX = (cx - bounds.startX) * ts;
+      const screenY = (cy - bounds.startY) * ts;
+
+      // Orange highlight background
+      ctx.fillStyle = 'rgba(243, 156, 18, 0.85)';
+      ctx.fillRect(screenX, screenY, ts, ts);
+
+      // Cursor bullet
+      ctx.fillStyle = '#2c3e50';
+      ctx.font = 'bold 16px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('\u25CF', screenX + ts / 2, screenY + ts / 2);
+    }
+  }
+
+  // --- Private: Helpers ---
+
+  _formatKeyName(keyId) {
+    return keyId
+      .split('_')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
+  }
+
+  _showCollectibleKeyFeedback(collectibleKey) {
+    const el = document.createElement('div');
+    el.className = 'key-collection-feedback';
+    el.textContent = `Found ${this._formatKeyName(collectibleKey.keyId)}!`;
+    document.body.appendChild(el);
+    setTimeout(() => {
+      if (document.body.contains(el)) document.body.removeChild(el);
+    }, 2000);
+  }
+
+  _getNpcFallbackSymbol(npc) {
+    const symbols = {
+      caret_spirit: '\uD83D\uDD25',
+      syntax_wisp: '~',
+      bug_king: '\u265B',
+      bug_king_boss: '\u265B',
+      caret_stone: '\uD83D\uDDFF',
+      maze_scribe: '\uD83D\uDCDC',
+      mode_guardian: '\uD83D\uDCDC',
+      deletion_echo: '\uD83D\uDC7B',
+      insert_scribe: '\u270F\uFE0F',
+      scribe_poet: '\u270F\uFE0F',
+      the_yanker: '\uD83C\uDF89',
+      mirror_sprite: '\uD83D\uDCA7',
+      reflection_spirit: '\uD83D\uDCA7',
+      practice_buddy: '\uD83C\uDF89',
+      practice_spirit_1: '\uD83C\uDF89',
+      practice_spirit_2: '\uD83C\uDF89',
+      practice_spirit_3: '\uD83C\uDF89',
+      final_encourager: '\uD83C\uDF89',
+      syntax_spirit: '\uD83D\uDCDC',
+      word_witch: '\uD83D\uDC7B',
+    };
+    if (npc.id && symbols[npc.id]) return symbols[npc.id];
+    if (npc.type && symbols[npc.type]) return symbols[npc.type];
+    return '\uD83E\uDDD9\u200D\u2642\uFE0F';
+  }
+
+  _findNPCScreenPosition(npc) {
+    if (!npc || !npc.position) return null;
+    const npcX = Array.isArray(npc.position) ? npc.position[0] : npc.position.x;
+    const npcY = Array.isArray(npc.position) ? npc.position[1] : npc.position.y;
+    return this._camera.worldToScreen(npcX, npcY);
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ import { CutsceneProviderAdapter } from './infrastructure/data/CutsceneProviderA
 import { CutsceneRenderer } from './infrastructure/ui/CutsceneRenderer.js';
 import { LevelSelectorUI } from './infrastructure/ui/LevelSelectorUI.js';
 import { FeatureFlags } from './infrastructure/FeatureFlags.js';
+import { CanvasGameRenderer } from './infrastructure/ui/CanvasGameRenderer.js';
 
 
 /**
@@ -67,11 +68,20 @@ class Application {
       this._cutsceneRenderer = null;
     }
 
+    // Create game renderer based on feature flag
+    const gameRenderer = featureFlags.isEnabled('CANVAS_RENDERER')
+      ? new CanvasGameRenderer()
+      : null; // null falls back to DOMGameRenderer in VimForKidsGame
+
     // Create game factory and initialization service
-    const gameFactory = new GameFactory({
+    const factoryDependencies = {
       cutsceneService: this._cutsceneService,
       cutsceneRenderer: this._cutsceneRenderer,
-    });
+    };
+    if (gameRenderer) {
+      factoryDependencies.gameRenderer = gameRenderer;
+    }
+    const gameFactory = new GameFactory(factoryDependencies);
     this._initializationService = new GameInitializationService(
       gameFactory,
       this._persistenceService,

--- a/style.css
+++ b/style.css
@@ -306,6 +306,22 @@ h1 {
   transform: translate(-50%, -50%);
 }
 
+/* Canvas-based game board */
+.game-board-canvas {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  outline: none;
+  cursor: pointer;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+.game-board-canvas:focus {
+  box-shadow: 0 0 10px rgba(231, 76, 60, 0.5);
+}
+
 /* Welcome Meadow specific grid */
 .game-board.welcome-meadow {
   justify-content: start;

--- a/tests/infrastructure/rendering/AssetLoader.test.js
+++ b/tests/infrastructure/rendering/AssetLoader.test.js
@@ -1,0 +1,104 @@
+import { AssetLoader } from '../../../src/infrastructure/rendering/AssetLoader.js';
+
+describe('AssetLoader', () => {
+  let loader;
+  let originalImage;
+
+  beforeEach(() => {
+    loader = new AssetLoader();
+
+    // Mock Image constructor
+    originalImage = global.Image;
+    global.Image = class MockImage {
+      constructor() {
+        this._src = '';
+        this.onload = null;
+        this.onerror = null;
+      }
+
+      get src() {
+        return this._src;
+      }
+
+      set src(value) {
+        this._src = value;
+        // Auto-trigger onload in next microtask
+        Promise.resolve().then(() => {
+          if (this.onload) this.onload();
+        });
+      }
+    };
+  });
+
+  afterEach(() => {
+    global.Image = originalImage;
+  });
+
+  describe('constructor', () => {
+    it('initializes as not loaded', () => {
+      expect(loader.isLoaded).toBe(false);
+    });
+  });
+
+  describe('loadImage', () => {
+    it('resolves with Image on success', async () => {
+      const img = await loader.loadImage('test.png');
+      expect(img).toBeDefined();
+      expect(img.src).toBe('test.png');
+    });
+
+    it('rejects on error', async () => {
+      global.Image = class FailImage {
+        constructor() {
+          this._src = '';
+          this.onload = null;
+          this.onerror = null;
+        }
+
+        get src() {
+          return this._src;
+        }
+
+        set src(value) {
+          this._src = value;
+          Promise.resolve().then(() => {
+            if (this.onerror) this.onerror();
+          });
+        }
+      };
+
+      await expect(loader.loadImage('bad.png')).rejects.toThrow('Failed to load image: bad.png');
+    });
+  });
+
+  describe('loadAll', () => {
+    it('loads all assets from manifest', async () => {
+      await loader.loadAll({
+        tileset: 'tileset.png',
+        characters: 'characters.png',
+      });
+
+      expect(loader.isLoaded).toBe(true);
+      expect(loader.getAsset('tileset')).not.toBeNull();
+      expect(loader.getAsset('characters')).not.toBeNull();
+    });
+
+    it('sets isLoaded to true after completion', async () => {
+      await loader.loadAll({ test: 'test.png' });
+      expect(loader.isLoaded).toBe(true);
+    });
+  });
+
+  describe('getAsset', () => {
+    it('returns null for unknown asset', () => {
+      expect(loader.getAsset('nonexistent')).toBeNull();
+    });
+
+    it('returns loaded asset by name', async () => {
+      await loader.loadAll({ myAsset: 'my.png' });
+      const asset = loader.getAsset('myAsset');
+      expect(asset).not.toBeNull();
+      expect(asset.src).toBe('my.png');
+    });
+  });
+});

--- a/tests/infrastructure/rendering/Camera.test.js
+++ b/tests/infrastructure/rendering/Camera.test.js
@@ -1,0 +1,184 @@
+import { Camera } from '../../../src/infrastructure/rendering/Camera.js';
+
+describe('Camera', () => {
+  let camera;
+  const mapBounds = { width: 80, height: 40 };
+
+  beforeEach(() => {
+    camera = new Camera(32);
+  });
+
+  describe('constructor', () => {
+    it('initializes with default values', () => {
+      expect(camera.x).toBe(0);
+      expect(camera.y).toBe(0);
+      expect(camera.tileSize).toBe(32);
+      expect(camera.viewportWidth).toBe(15);
+      expect(camera.viewportHeight).toBe(10);
+      expect(camera.isInitialized).toBe(false);
+    });
+  });
+
+  describe('setViewportSize', () => {
+    it('calculates viewport dimensions from screen size', () => {
+      camera.setViewportSize(960, 600);
+      expect(camera.viewportWidth).toBe(30); // 960/32
+      expect(camera.viewportHeight).toBe(15); // (600-120)/32
+    });
+
+    it('enforces minimum viewport size', () => {
+      camera.setViewportSize(100, 100);
+      expect(camera.viewportWidth).toBe(15);
+      expect(camera.viewportHeight).toBe(10);
+    });
+
+    it('uses custom UI offset', () => {
+      camera.setViewportSize(960, 600, 200);
+      expect(camera.viewportHeight).toBe(12); // (600-200)/32 = 12.5 -> 12
+    });
+  });
+
+  describe('update', () => {
+    it('centers on first call (not initialized)', () => {
+      const result = camera.update({ x: 40, y: 20 }, mapBounds);
+      expect(result).toBe(true); // centered
+      expect(camera.isInitialized).toBe(true);
+    });
+
+    it('centers when cursor jumps more than 5 tiles', () => {
+      camera.update({ x: 10, y: 10 }, mapBounds);
+      const result = camera.update({ x: 50, y: 10 }, mapBounds);
+      expect(result).toBe(true); // re-centered
+    });
+
+    it('scrolls when cursor moves within normal range', () => {
+      camera.update({ x: 10, y: 10 }, mapBounds);
+      const result = camera.update({ x: 11, y: 10 }, mapBounds);
+      expect(result).toBe(false); // scrolled, not centered
+    });
+
+    it('does not change when cursor has not moved', () => {
+      camera.update({ x: 10, y: 10 }, mapBounds);
+      const result = camera.update({ x: 10, y: 10 }, mapBounds);
+      expect(result).toBe(false);
+    });
+
+    it('uses zone bounds for centering when provided', () => {
+      const zoneBounds = { minX: 20, minY: 5, maxX: 60, maxY: 30 };
+      camera.update({ x: 30, y: 15 }, mapBounds, zoneBounds);
+      // Camera x should be based on zone minX, not cursor
+      expect(camera.x).toBe(zoneBounds.minX - Math.floor(camera.viewportWidth / 2));
+    });
+  });
+
+  describe('interpolate', () => {
+    it('returns false when already at target', () => {
+      const result = camera.interpolate();
+      expect(result).toBe(false);
+    });
+
+    it('returns true when still moving toward target', () => {
+      camera.update({ x: 40, y: 20 }, mapBounds);
+      // Force target different from current
+      camera._targetX = camera._x + 10;
+      const result = camera.interpolate();
+      expect(result).toBe(true);
+    });
+
+    it('moves toward target with smoothing factor', () => {
+      camera._x = 0;
+      camera._targetX = 10;
+      camera.interpolate();
+      expect(camera.x).toBeCloseTo(1.5, 1); // 10 * 0.15
+    });
+
+    it('snaps to target when very close', () => {
+      camera._x = 9.95;
+      camera._targetX = 10;
+      camera.interpolate();
+      expect(camera.x).toBe(10);
+    });
+  });
+
+  describe('getVisibleBounds', () => {
+    it('returns viewport bounds based on camera position', () => {
+      camera._x = 5;
+      camera._y = 3;
+      const bounds = camera.getVisibleBounds();
+      expect(bounds.startX).toBe(5);
+      expect(bounds.startY).toBe(3);
+      expect(bounds.endX).toBe(5 + camera.viewportWidth);
+      expect(bounds.endY).toBe(3 + camera.viewportHeight);
+    });
+
+    it('floors fractional camera positions', () => {
+      camera._x = 5.7;
+      camera._y = 3.2;
+      const bounds = camera.getVisibleBounds();
+      expect(bounds.startX).toBe(5);
+      expect(bounds.startY).toBe(3);
+    });
+  });
+
+  describe('worldToScreen', () => {
+    it('converts world coordinates to screen pixels', () => {
+      camera._x = 5;
+      camera._y = 3;
+      const screen = camera.worldToScreen(7, 5);
+      expect(screen.x).toBe((7 - 5) * 32); // 64
+      expect(screen.y).toBe((5 - 3) * 32); // 64
+    });
+
+    it('handles fractional camera position', () => {
+      camera._x = 5.5;
+      camera._y = 0;
+      const screen = camera.worldToScreen(6, 0);
+      expect(screen.x).toBeCloseTo(16, 0); // (6-5.5)*32 = 16
+    });
+  });
+
+  describe('reset', () => {
+    it('resets all camera state', () => {
+      camera.update({ x: 40, y: 20 }, mapBounds);
+      camera.reset();
+      expect(camera.x).toBe(0);
+      expect(camera.y).toBe(0);
+      expect(camera.isInitialized).toBe(false);
+    });
+  });
+
+  describe('_shouldCenterOnZone', () => {
+    it('returns true when not initialized', () => {
+      expect(camera._shouldCenterOnZone('10,10', { x: 10, y: 10 })).toBe(true);
+    });
+
+    it('returns false when cursor has not moved', () => {
+      camera._isInitialized = true;
+      camera._lastCursorKey = '10,10';
+      expect(camera._shouldCenterOnZone('10,10', { x: 10, y: 10 })).toBe(false);
+    });
+
+    it('returns true when cursor jumps far', () => {
+      camera._isInitialized = true;
+      camera._lastCursorKey = '10,10';
+      expect(camera._shouldCenterOnZone('20,20', { x: 20, y: 20 })).toBe(true);
+    });
+
+    it('returns false when cursor moves small amount', () => {
+      camera._isInitialized = true;
+      camera._lastCursorKey = '10,10';
+      expect(camera._shouldCenterOnZone('11,10', { x: 11, y: 10 })).toBe(false);
+    });
+  });
+
+  describe('_updateScrolling', () => {
+    it('clamps target to map bounds', () => {
+      camera._isInitialized = true;
+      camera._lastCursorKey = '1,1';
+      camera.update({ x: 2, y: 1 }, { width: 20, height: 15 });
+      // Target should not exceed map bounds
+      expect(camera._targetY).toBeGreaterThanOrEqual(0);
+      expect(camera._targetX).toBeLessThanOrEqual(20 - camera.viewportWidth);
+    });
+  });
+});

--- a/tests/infrastructure/rendering/EntityIndex.test.js
+++ b/tests/infrastructure/rendering/EntityIndex.test.js
@@ -1,0 +1,131 @@
+import { EntityIndex } from '../../../src/infrastructure/rendering/EntityIndex.js';
+
+describe('EntityIndex', () => {
+  let index;
+
+  beforeEach(() => {
+    index = new EntityIndex();
+  });
+
+  function createMockGameState(overrides = {}) {
+    return {
+      availableKeys: overrides.availableKeys || [],
+      availableCollectibleKeys: overrides.availableCollectibleKeys || [],
+      npcs: overrides.npcs || [],
+      textLabels: overrides.textLabels || [],
+      gate: overrides.gate || null,
+      secondaryGates: overrides.secondaryGates || [],
+    };
+  }
+
+  describe('rebuild', () => {
+    it('indexes VIM keys by position', () => {
+      const gameState = createMockGameState({
+        availableKeys: [{ position: { x: 5, y: 10 }, key: 'h' }],
+      });
+      index.rebuild(gameState);
+      expect(index.getKeyAt(5, 10)).toEqual({ position: { x: 5, y: 10 }, key: 'h' });
+    });
+
+    it('indexes collectible keys by position', () => {
+      const gameState = createMockGameState({
+        availableCollectibleKeys: [{ position: { x: 3, y: 7 }, keyId: 'maze_key', color: 'gold' }],
+      });
+      index.rebuild(gameState);
+      expect(index.getCollectibleAt(3, 7).keyId).toBe('maze_key');
+    });
+
+    it('indexes NPCs by array position', () => {
+      const gameState = createMockGameState({
+        npcs: [{ id: 'caret_spirit', position: [8, 12] }],
+      });
+      index.rebuild(gameState);
+      expect(index.getNPCAt(8, 12).id).toBe('caret_spirit');
+    });
+
+    it('skips NPCs without valid position', () => {
+      const gameState = createMockGameState({
+        npcs: [{ id: 'broken', position: null }],
+      });
+      index.rebuild(gameState);
+      expect(index.getNPCAt(0, 0)).toBeNull();
+    });
+
+    it('indexes text labels by position', () => {
+      const gameState = createMockGameState({
+        textLabels: [{ position: { x: 2, y: 3 }, text: 'H', color: '#fff' }],
+      });
+      index.rebuild(gameState);
+      expect(index.getTextLabelAt(2, 3).text).toBe('H');
+    });
+
+    it('indexes main gate', () => {
+      const gameState = createMockGameState({
+        gate: { position: { x: 15, y: 5 }, isOpen: false },
+      });
+      index.rebuild(gameState);
+      expect(index.getGateAt(15, 5)).not.toBeNull();
+      expect(index.getGateAt(15, 5).isOpen).toBe(false);
+    });
+
+    it('indexes closed secondary gates only', () => {
+      const gameState = createMockGameState({
+        secondaryGates: [
+          { position: { x: 10, y: 8 }, isOpen: false },
+          { position: { x: 12, y: 8 }, isOpen: true },
+        ],
+      });
+      index.rebuild(gameState);
+      expect(index.getSecondaryGateAt(10, 8)).not.toBeNull();
+      expect(index.getSecondaryGateAt(12, 8)).toBeNull(); // open gates not indexed
+    });
+
+    it('clears previous data on rebuild', () => {
+      index.rebuild(
+        createMockGameState({
+          availableKeys: [{ position: { x: 1, y: 1 }, key: 'h' }],
+        })
+      );
+      index.rebuild(createMockGameState());
+      expect(index.getKeyAt(1, 1)).toBeNull();
+    });
+  });
+
+  describe('lookup methods', () => {
+    it('returns null for empty positions', () => {
+      index.rebuild(createMockGameState());
+      expect(index.getKeyAt(0, 0)).toBeNull();
+      expect(index.getCollectibleAt(0, 0)).toBeNull();
+      expect(index.getNPCAt(0, 0)).toBeNull();
+      expect(index.getTextLabelAt(0, 0)).toBeNull();
+      expect(index.getGateAt(0, 0)).toBeNull();
+      expect(index.getSecondaryGateAt(0, 0)).toBeNull();
+    });
+
+    it('returns null for gate when no gate exists', () => {
+      index.rebuild(createMockGameState());
+      expect(index.getGateAt(0, 0)).toBeNull();
+    });
+
+    it('returns null for gate at wrong position', () => {
+      index.rebuild(
+        createMockGameState({
+          gate: { position: { x: 5, y: 5 }, isOpen: false },
+        })
+      );
+      expect(index.getGateAt(6, 5)).toBeNull();
+    });
+  });
+
+  describe('handles missing properties gracefully', () => {
+    it('handles gameState with undefined properties', () => {
+      index.rebuild({});
+      expect(index.getKeyAt(0, 0)).toBeNull();
+    });
+
+    it('handles null availableKeys', () => {
+      index.rebuild({ availableKeys: null });
+      expect(index.getKeyAt(0, 0)).toBeNull();
+    });
+  });
+});

--- a/tests/infrastructure/rendering/GameLoop.test.js
+++ b/tests/infrastructure/rendering/GameLoop.test.js
@@ -1,0 +1,165 @@
+import { GameLoop } from '../../../src/infrastructure/rendering/GameLoop.js';
+
+describe('GameLoop', () => {
+  let mockUpdate;
+  let mockDraw;
+  let gameLoop;
+  let rafCallbacks;
+  let rafIdCounter;
+
+  beforeEach(() => {
+    mockUpdate = jest.fn();
+    mockDraw = jest.fn();
+    rafCallbacks = new Map();
+    rafIdCounter = 0;
+
+    global.requestAnimationFrame = jest.fn((callback) => {
+      const id = ++rafIdCounter;
+      rafCallbacks.set(id, callback);
+      return id;
+    });
+
+    global.cancelAnimationFrame = jest.fn((id) => {
+      rafCallbacks.delete(id);
+    });
+
+    gameLoop = new GameLoop(mockUpdate, mockDraw);
+  });
+
+  afterEach(() => {
+    if (gameLoop.isRunning) {
+      gameLoop.stop();
+    }
+    delete global.requestAnimationFrame;
+    delete global.cancelAnimationFrame;
+  });
+
+  function simulateFrame(timestamp) {
+    const lastId = rafIdCounter;
+    const callback = rafCallbacks.get(lastId);
+    if (callback) {
+      rafCallbacks.delete(lastId);
+      callback(timestamp);
+    }
+  }
+
+  describe('constructor', () => {
+    it('throws if updateFn is not a function', () => {
+      expect(() => new GameLoop(null, mockDraw)).toThrow('updateFn must be a function');
+    });
+
+    it('throws if drawFn is not a function', () => {
+      expect(() => new GameLoop(mockUpdate, 'not-a-fn')).toThrow('drawFn must be a function');
+    });
+
+    it('initializes as not running', () => {
+      expect(gameLoop.isRunning).toBe(false);
+    });
+  });
+
+  describe('start', () => {
+    it('sets isRunning to true', () => {
+      gameLoop.start();
+      expect(gameLoop.isRunning).toBe(true);
+    });
+
+    it('requests an animation frame', () => {
+      gameLoop.start();
+      expect(global.requestAnimationFrame).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing if already running', () => {
+      gameLoop.start();
+      gameLoop.start();
+      expect(global.requestAnimationFrame).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stop', () => {
+    it('sets isRunning to false', () => {
+      gameLoop.start();
+      gameLoop.stop();
+      expect(gameLoop.isRunning).toBe(false);
+    });
+
+    it('cancels the pending animation frame', () => {
+      gameLoop.start();
+      gameLoop.stop();
+      expect(global.cancelAnimationFrame).toHaveBeenCalledWith(1);
+    });
+
+    it('does nothing if not running', () => {
+      gameLoop.stop();
+      expect(global.cancelAnimationFrame).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_tick', () => {
+    it('calls update with 0 deltaTime on first frame', () => {
+      gameLoop.start();
+      simulateFrame(1000);
+      expect(mockUpdate).toHaveBeenCalledWith(0);
+    });
+
+    it('calculates deltaTime between frames in seconds', () => {
+      gameLoop.start();
+      simulateFrame(1000);
+      simulateFrame(1016.67); // ~60fps
+      expect(mockUpdate).toHaveBeenLastCalledWith(expect.closeTo(0.01667, 4));
+    });
+
+    it('calls draw when redraw is needed', () => {
+      gameLoop.start();
+      simulateFrame(1000);
+      expect(mockDraw).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips draw when no redraw requested', () => {
+      gameLoop.start();
+      simulateFrame(1000); // draws (initial needsRedraw=true)
+      simulateFrame(1016); // should not draw
+      expect(mockDraw).toHaveBeenCalledTimes(1);
+    });
+
+    it('draws again after requestRedraw', () => {
+      gameLoop.start();
+      simulateFrame(1000);
+      gameLoop.requestRedraw();
+      simulateFrame(1016);
+      expect(mockDraw).toHaveBeenCalledTimes(2);
+    });
+
+    it('caps deltaTime at 0.1 seconds', () => {
+      gameLoop.start();
+      simulateFrame(1000);
+      simulateFrame(2000); // 1 second gap (tab switch)
+      expect(mockUpdate).toHaveBeenLastCalledWith(0.1);
+    });
+
+    it('schedules next frame after tick', () => {
+      gameLoop.start();
+      expect(global.requestAnimationFrame).toHaveBeenCalledTimes(1);
+      simulateFrame(1000);
+      expect(global.requestAnimationFrame).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not tick after stop', () => {
+      gameLoop.start();
+      gameLoop.stop();
+      simulateFrame(1000);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestRedraw', () => {
+    it('marks loop for redraw on next frame', () => {
+      gameLoop.start();
+      simulateFrame(1000); // consumes initial needsRedraw
+      mockDraw.mockClear();
+
+      gameLoop.requestRedraw();
+      simulateFrame(1016);
+      expect(mockDraw).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/infrastructure/rendering/SpriteSheet.test.js
+++ b/tests/infrastructure/rendering/SpriteSheet.test.js
@@ -1,0 +1,89 @@
+import { SpriteSheet } from '../../../src/infrastructure/rendering/SpriteSheet.js';
+
+describe('SpriteSheet', () => {
+  let mockImage;
+
+  beforeEach(() => {
+    mockImage = { width: 160, height: 160, src: 'test.png' };
+  });
+
+  describe('constructor', () => {
+    it('creates a sprite sheet with valid parameters', () => {
+      const sheet = new SpriteSheet(mockImage, 16, 16, 10);
+      expect(sheet.image).toBe(mockImage);
+      expect(sheet.tileWidth).toBe(16);
+      expect(sheet.tileHeight).toBe(16);
+    });
+
+    it('throws if image is null', () => {
+      expect(() => new SpriteSheet(null, 16, 16, 10)).toThrow('valid image');
+    });
+
+    it('throws if tile dimensions are zero', () => {
+      expect(() => new SpriteSheet(mockImage, 0, 16, 10)).toThrow('positive');
+    });
+
+    it('throws if tile dimensions are negative', () => {
+      expect(() => new SpriteSheet(mockImage, -1, 16, 10)).toThrow('positive');
+    });
+
+    it('throws if columns is zero', () => {
+      expect(() => new SpriteSheet(mockImage, 16, 16, 0)).toThrow('positive');
+    });
+  });
+
+  describe('getFrame', () => {
+    it('returns correct source rect for first frame', () => {
+      const sheet = new SpriteSheet(mockImage, 16, 16, 10);
+      const frame = sheet.getFrame(0);
+      expect(frame).toEqual({
+        image: mockImage,
+        sx: 0,
+        sy: 0,
+        sw: 16,
+        sh: 16,
+      });
+    });
+
+    it('returns correct source rect for frame in first row', () => {
+      const sheet = new SpriteSheet(mockImage, 16, 16, 10);
+      const frame = sheet.getFrame(5);
+      expect(frame).toEqual({
+        image: mockImage,
+        sx: 80, // 5 * 16
+        sy: 0,
+        sw: 16,
+        sh: 16,
+      });
+    });
+
+    it('wraps to next row correctly', () => {
+      const sheet = new SpriteSheet(mockImage, 16, 16, 10);
+      const frame = sheet.getFrame(15);
+      expect(frame).toEqual({
+        image: mockImage,
+        sx: 80, // (15 % 10) * 16
+        sy: 16, // floor(15 / 10) * 16
+        sw: 16,
+        sh: 16,
+      });
+    });
+
+    it('handles non-square tiles', () => {
+      const sheet = new SpriteSheet(mockImage, 32, 16, 5);
+      const frame = sheet.getFrame(7);
+      expect(frame).toEqual({
+        image: mockImage,
+        sx: 64, // (7 % 5) * 32
+        sy: 16, // floor(7 / 5) * 16
+        sw: 32,
+        sh: 16,
+      });
+    });
+
+    it('throws for negative index', () => {
+      const sheet = new SpriteSheet(mockImage, 16, 16, 10);
+      expect(() => sheet.getFrame(-1)).toThrow('non-negative');
+    });
+  });
+});

--- a/tests/infrastructure/ui/CanvasGameRenderer.test.js
+++ b/tests/infrastructure/ui/CanvasGameRenderer.test.js
@@ -1,0 +1,455 @@
+import { CanvasGameRenderer } from '../../../src/infrastructure/ui/CanvasGameRenderer.js';
+
+describe('CanvasGameRenderer', () => {
+  let renderer;
+  let mockCtx;
+
+  beforeEach(() => {
+    // Clear DOM
+    document.body.innerHTML = '';
+
+    // Create required DOM structure
+    const container = document.createElement('div');
+    container.id = 'game-container';
+
+    const gameBoard = document.createElement('div');
+    gameBoard.id = 'gameBoard';
+    container.appendChild(gameBoard);
+
+    const keysDisplay = document.createElement('div');
+    keysDisplay.className = 'key-display';
+    container.appendChild(keysDisplay);
+
+    const collectibleDisplay = document.createElement('div');
+    collectibleDisplay.className = 'collectible-display';
+    container.appendChild(collectibleDisplay);
+
+    document.body.appendChild(container);
+
+    // Mock canvas context
+    mockCtx = {
+      clearRect: jest.fn(),
+      fillRect: jest.fn(),
+      fillText: jest.fn(),
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+      drawImage: jest.fn(),
+      fillStyle: '',
+      font: '',
+      textAlign: '',
+      textBaseline: '',
+    };
+
+    HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(mockCtx);
+
+    // Mock rAF
+    global.requestAnimationFrame = jest.fn((cb) => {
+      return 1;
+    });
+    global.cancelAnimationFrame = jest.fn();
+
+    renderer = new CanvasGameRenderer();
+  });
+
+  afterEach(() => {
+    if (renderer && renderer.cleanup) {
+      renderer.cleanup();
+    }
+    delete global.requestAnimationFrame;
+    delete global.cancelAnimationFrame;
+    jest.restoreAllMocks();
+  });
+
+  function createMockGameState(overrides = {}) {
+    const Position = class {
+      constructor(x, y) {
+        this._x = x;
+        this._y = y;
+      }
+      get x() {
+        return this._x;
+      }
+      get y() {
+        return this._y;
+      }
+      equals(other) {
+        return other && this._x === other.x && this._y === other.y;
+      }
+    };
+
+    const cursorPos = overrides.cursorPosition || { x: 5, y: 5 };
+
+    return {
+      map: {
+        width: overrides.mapWidth || 20,
+        height: overrides.mapHeight || 20,
+        size: overrides.mapWidth || 20,
+        getTileAt: jest.fn().mockReturnValue({ name: 'grass', walkable: true }),
+      },
+      cursor: {
+        position: new Position(cursorPos.x, cursorPos.y),
+      },
+      availableKeys: overrides.availableKeys || [],
+      availableCollectibleKeys: overrides.availableCollectibleKeys || [],
+      collectedKeys: overrides.collectedKeys || new Set(),
+      collectedCollectibleKeys: overrides.collectedCollectibleKeys || new Set(),
+      textLabels: overrides.textLabels || [],
+      gate: overrides.gate || null,
+      secondaryGates: overrides.secondaryGates || [],
+      npcs: overrides.npcs || [],
+    };
+  }
+
+  describe('constructor', () => {
+    it('creates a canvas element', () => {
+      expect(renderer.gameBoard).toBeDefined();
+      expect(renderer.gameBoard.tagName).toBe('CANVAS');
+    });
+
+    it('sets canvas as focusable', () => {
+      expect(renderer.gameBoard.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('hides the existing DOM gameBoard', () => {
+      const originalBoard = document.getElementById('gameBoard');
+      expect(originalBoard.style.display).toBe('none');
+    });
+
+    it('starts the game loop', () => {
+      expect(global.requestAnimationFrame).toHaveBeenCalled();
+    });
+  });
+
+  describe('render', () => {
+    it('stores current game state', () => {
+      const state = createMockGameState();
+      renderer.render(state);
+      expect(renderer._currentGameState).toBe(state);
+    });
+
+    it('rebuilds entity index', () => {
+      const spy = jest.spyOn(renderer._entityIndex, 'rebuild');
+      const state = createMockGameState();
+      renderer.render(state);
+      expect(spy).toHaveBeenCalledWith(state);
+    });
+
+    it('updates camera with cursor position', () => {
+      const spy = jest.spyOn(renderer._camera, 'update');
+      const state = createMockGameState({ cursorPosition: { x: 10, y: 8 } });
+      renderer.render(state);
+      expect(spy).toHaveBeenCalled();
+      expect(spy.mock.calls[0][0].x).toBe(10);
+      expect(spy.mock.calls[0][0].y).toBe(8);
+    });
+
+    it('requests redraw from game loop', () => {
+      const spy = jest.spyOn(renderer._gameLoop, 'requestRedraw');
+      renderer.render(createMockGameState());
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('_draw', () => {
+    it('clears the canvas', () => {
+      renderer.render(createMockGameState());
+      renderer._draw(0);
+      expect(mockCtx.clearRect).toHaveBeenCalledWith(
+        0,
+        0,
+        renderer.gameBoard.width,
+        renderer.gameBoard.height
+      );
+    });
+
+    it('draws tile rectangles', () => {
+      renderer.render(createMockGameState());
+      renderer._draw(0);
+      expect(mockCtx.fillRect).toHaveBeenCalled();
+    });
+
+    it('draws cursor', () => {
+      renderer.render(createMockGameState({ cursorPosition: { x: 5, y: 5 } }));
+      renderer._draw(0);
+      // Cursor fillText for the bullet character
+      const fillTextCalls = mockCtx.fillText.mock.calls;
+      const cursorCall = fillTextCalls.find((c) => c[0] === '\u25CF');
+      expect(cursorCall).toBeDefined();
+    });
+
+    it('does not draw when no game state', () => {
+      renderer._draw(0);
+      expect(mockCtx.clearRect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_drawEntitiesAt', () => {
+    it('draws VIM keys', () => {
+      const state = createMockGameState({
+        availableKeys: [
+          {
+            position: { x: 3, y: 3 },
+            key: 'h',
+          },
+        ],
+      });
+      renderer.render(state);
+      renderer._drawEntitiesAt(mockCtx, 3, 3, 0, 0, 32);
+      const calls = mockCtx.fillText.mock.calls;
+      expect(calls.some((c) => c[0] === 'h')).toBe(true);
+    });
+
+    it('draws NPCs with visual symbol', () => {
+      const state = createMockGameState({
+        npcs: [{ id: 'caret_spirit', position: [4, 4], getVisualSymbol: () => '\uD83D\uDD25' }],
+      });
+      renderer.render(state);
+      renderer._drawEntitiesAt(mockCtx, 4, 4, 0, 0, 32);
+      const calls = mockCtx.fillText.mock.calls;
+      expect(calls.some((c) => c[0] === '\uD83D\uDD25')).toBe(true);
+    });
+
+    it('draws NPC fallback symbol when no getVisualSymbol', () => {
+      const state = createMockGameState({
+        npcs: [{ id: 'bug_king', position: [4, 4] }],
+      });
+      renderer.render(state);
+      renderer._drawEntitiesAt(mockCtx, 4, 4, 0, 0, 32);
+      const calls = mockCtx.fillText.mock.calls;
+      expect(calls.some((c) => c[0] === '\u265B')).toBe(true);
+    });
+
+    it('draws text labels', () => {
+      const state = createMockGameState({
+        textLabels: [{ position: { x: 2, y: 2 }, text: 'H', color: '#fff', fontSize: '12px' }],
+      });
+      renderer.render(state);
+      renderer._drawEntitiesAt(mockCtx, 2, 2, 0, 0, 32);
+      const calls = mockCtx.fillText.mock.calls;
+      expect(calls.some((c) => c[0] === 'H')).toBe(true);
+    });
+
+    it('draws gates', () => {
+      const state = createMockGameState({
+        gate: { position: { x: 5, y: 5 }, isOpen: false },
+      });
+      renderer.render(state);
+      renderer._drawEntitiesAt(mockCtx, 5, 5, 0, 0, 32);
+      expect(mockCtx.fillRect).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateCollectedKeysDisplay', () => {
+    it('shows empty message when no keys collected', () => {
+      renderer.updateCollectedKeysDisplay(new Set());
+      const display = document.querySelector('.key-display');
+      expect(display.textContent).toContain('No keys collected yet!');
+    });
+
+    it('shows collected key names', () => {
+      renderer.updateCollectedKeysDisplay(new Set(['h', 'j']));
+      const display = document.querySelector('.key-display');
+      const keys = display.querySelectorAll('.collected-key');
+      expect(keys).toHaveLength(2);
+      expect(keys[0].textContent).toBe('h');
+      expect(keys[1].textContent).toBe('j');
+    });
+  });
+
+  describe('updateCollectibleInventoryDisplay', () => {
+    it('shows empty message when no collectibles', () => {
+      renderer.updateCollectibleInventoryDisplay(new Set());
+      const display = document.querySelector('.collectible-display');
+      expect(display.textContent).toContain('No special keys found yet!');
+    });
+
+    it('shows collected collectible keys', () => {
+      renderer.updateCollectibleInventoryDisplay(new Set(['maze_key']));
+      const display = document.querySelector('.collectible-display');
+      const keys = display.querySelectorAll('.collected-collectible-key');
+      expect(keys).toHaveLength(1);
+      expect(keys[0].textContent).toContain('Maze Key');
+    });
+  });
+
+  describe('showKeyInfo', () => {
+    it('shows feedback for collectible keys', () => {
+      renderer.showKeyInfo({ type: 'collectible_key', keyId: 'maze_key' });
+      const feedback = document.querySelector('.key-collection-feedback');
+      expect(feedback).not.toBeNull();
+      expect(feedback.textContent).toContain('Maze Key');
+    });
+
+    it('does nothing for VIM keys', () => {
+      renderer.showKeyInfo({ type: 'vim_key', key: 'h' });
+      const feedback = document.querySelector('.key-collection-feedback');
+      expect(feedback).toBeNull();
+    });
+  });
+
+  describe('showMessage', () => {
+    it('creates a message bubble', () => {
+      renderer.showMessage('Hello world');
+      const bubble = document.querySelector('.message-bubble');
+      expect(bubble).not.toBeNull();
+      expect(bubble.textContent).toContain('Hello world');
+    });
+
+    it('includes speaker name when provided', () => {
+      renderer.showMessage('Greetings', { speaker: 'NPC' });
+      const speaker = document.querySelector('.message-speaker');
+      expect(speaker.textContent).toBe('NPC');
+    });
+
+    it('includes close button', () => {
+      renderer.showMessage('Test');
+      const closeBtn = document.querySelector('.message-close');
+      expect(closeBtn).not.toBeNull();
+    });
+
+    it('auto-hides after duration', () => {
+      jest.useFakeTimers();
+      renderer.showMessage('Test', { duration: 2000 });
+      expect(document.querySelector('.message-bubble')).not.toBeNull();
+      jest.advanceTimersByTime(2000);
+      expect(document.querySelector('.message-bubble')).toBeNull();
+      jest.useRealTimers();
+    });
+
+    it('removes previous message', () => {
+      renderer.showMessage('First');
+      renderer.showMessage('Second');
+      const bubbles = document.querySelectorAll('.message-bubble');
+      expect(bubbles).toHaveLength(1);
+      expect(bubbles[0].textContent).toContain('Second');
+    });
+  });
+
+  describe('hideMessage', () => {
+    it('removes current message', () => {
+      renderer.showMessage('Test');
+      renderer.hideMessage();
+      expect(document.querySelector('.message-bubble')).toBeNull();
+    });
+
+    it('does nothing when no message displayed', () => {
+      expect(() => renderer.hideMessage()).not.toThrow();
+    });
+  });
+
+  describe('showNPCDialogue', () => {
+    it('joins array dialogue into single string', () => {
+      const spy = jest.spyOn(renderer, 'showNPCBalloon');
+      renderer.showNPCDialogue({ id: 'test' }, ['Hello', 'World']);
+      expect(spy).toHaveBeenCalledWith({ id: 'test' }, 'Hello World', {});
+    });
+
+    it('converts non-array dialogue to string', () => {
+      const spy = jest.spyOn(renderer, 'showNPCBalloon');
+      renderer.showNPCDialogue({ id: 'test' }, 'Single line');
+      expect(spy).toHaveBeenCalledWith({ id: 'test' }, 'Single line', {});
+    });
+  });
+
+  describe('showNPCBalloon', () => {
+    it('creates a balloon element', () => {
+      renderer.showNPCBalloon({ id: 'test' }, 'Hello');
+      const balloon = document.querySelector('.npc-balloon');
+      expect(balloon).not.toBeNull();
+      expect(balloon.textContent).toBe('Hello');
+    });
+
+    it('fades out existing balloons first', () => {
+      renderer.showNPCBalloon({ id: 'test' }, 'First');
+      renderer.showNPCBalloon({ id: 'test' }, 'Second');
+      const balloons = document.querySelectorAll('.npc-balloon:not(.fade-out)');
+      expect(balloons).toHaveLength(1);
+      expect(balloons[0].textContent).toBe('Second');
+    });
+
+    it('auto-removes after duration', () => {
+      jest.useFakeTimers();
+      renderer.showNPCBalloon({ id: 'test' }, 'Hello', { duration: 3000 });
+      expect(document.querySelector('.npc-balloon')).not.toBeNull();
+      jest.advanceTimersByTime(3000);
+      expect(document.querySelector('.npc-balloon')).toBeNull();
+      jest.useRealTimers();
+    });
+  });
+
+  describe('fadeOutExistingBalloons', () => {
+    it('adds fade-out class to existing balloons', () => {
+      renderer.showNPCBalloon({ id: 'test' }, 'Hello', { duration: 0 });
+      renderer.fadeOutExistingBalloons();
+      const balloons = document.querySelectorAll('.npc-balloon.fade-out');
+      expect(balloons).toHaveLength(1);
+    });
+
+    it('does not double-fade balloons', () => {
+      renderer.showNPCBalloon({ id: 'test' }, 'Hello', { duration: 0 });
+      renderer.fadeOutExistingBalloons();
+      renderer.fadeOutExistingBalloons();
+      // Should still only have 1 balloon (no duplicates)
+      const balloons = document.querySelectorAll('.npc-balloon');
+      expect(balloons).toHaveLength(1);
+    });
+  });
+
+  describe('focus', () => {
+    it('focuses the canvas element', () => {
+      const spy = jest.spyOn(renderer.gameBoard, 'focus');
+      renderer.focus();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('resetCamera', () => {
+    it('resets the camera state', () => {
+      const spy = jest.spyOn(renderer._camera, 'reset');
+      renderer.resetCamera();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('_formatKeyName', () => {
+    it('formats snake_case to Title Case', () => {
+      expect(renderer._formatKeyName('maze_key')).toBe('Maze Key');
+    });
+
+    it('capitalizes single word', () => {
+      expect(renderer._formatKeyName('golden')).toBe('Golden');
+    });
+  });
+
+  describe('_getNpcFallbackSymbol', () => {
+    it('returns symbol for known NPC id', () => {
+      expect(renderer._getNpcFallbackSymbol({ id: 'bug_king' })).toBe('\u265B');
+    });
+
+    it('returns symbol for known NPC type', () => {
+      expect(renderer._getNpcFallbackSymbol({ type: 'caret_spirit' })).toBe('\uD83D\uDD25');
+    });
+
+    it('returns default wizard for unknown NPC', () => {
+      expect(renderer._getNpcFallbackSymbol({ id: 'unknown' })).toBe(
+        '\uD83E\uDDD9\u200D\u2642\uFE0F'
+      );
+    });
+  });
+
+  describe('cleanup', () => {
+    it('stops the game loop', () => {
+      const spy = jest.spyOn(renderer._gameLoop, 'stop');
+      renderer.cleanup();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('removes canvas from DOM', () => {
+      renderer.cleanup();
+      expect(document.getElementById('gameBoardCanvas')).toBeNull();
+    });
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -51,7 +51,13 @@ export default defineConfig({
           // Split infrastructure into separate chunk
           infrastructure: [
             './src/infrastructure/ui/DOMGameRenderer.js',
+            './src/infrastructure/ui/CanvasGameRenderer.js',
             './src/infrastructure/input/KeyboardInputHandler.js',
+            './src/infrastructure/rendering/GameLoop.js',
+            './src/infrastructure/rendering/Camera.js',
+            './src/infrastructure/rendering/EntityIndex.js',
+            './src/infrastructure/rendering/SpriteSheet.js',
+            './src/infrastructure/rendering/AssetLoader.js',
           ],
         },
       },


### PR DESCRIPTION
## Summary

- Add `CanvasGameRenderer` implementing the `GameRenderer` port with HTML5 Canvas rendering and a `requestAnimationFrame` game loop for smooth 60fps operation
- Extract reusable rendering infrastructure: `GameLoop`, `Camera`, `EntityIndex`, `SpriteSheet`, `AssetLoader` — all with full test coverage
- Replace per-frame DOM `innerHTML` teardown + 750 linear `.find()` scans with Canvas draw calls + O(1) `Map` lookups
- Feature-flagged off by default (`CANVAS_RENDERER: false`) — existing `DOMGameRenderer` remains untouched as production default

## Details

| Component | Purpose |
|---|---|
| `GameLoop` | rAF cycle with deltaTime calculation, dirty flag, start/stop lifecycle |
| `Camera` | Pure-math viewport management with lerp smooth scrolling (extracted from DOMGameRenderer) |
| `EntityIndex` | O(1) Map-based entity lookups by `"x,y"` key |
| `SpriteSheet` | Sprite sheet frame extraction math |
| `AssetLoader` | Promise-based image loading |
| `CanvasGameRenderer` | Full port implementation; DOM overlays for UI chrome (messages, balloons, keys display) |

**No domain or application code was modified.** All 1521 tests pass with 86%+ coverage.

## Test plan

- [x] `npm run validate` passes (lint + format + test:coverage ≥80% + build)
- [ ] Default mode (DOM renderer): game works exactly as before — navigate with hjkl, collect keys, NPCs, gates
- [ ] Canvas mode: enable via `localStorage.setItem('remoteFeatureFlags', JSON.stringify({CANVAS_RENDERER: true}))` + reload — colored rectangles, smooth camera, all mechanics work
- [ ] Switch back: `localStorage.removeItem('remoteFeatureFlags')` + reload