### PR TITLE
feat: e vim key (end-of-word motion) + walls jumpable for word motions

### DIFF
--- a/src/application/use-cases/MovePlayerUseCase.js
+++ b/src/application/use-cases/MovePlayerUseCase.js
@@ -17,7 +17,10 @@ export class MovePlayerUseCase {
 
   async execute(direction) {
     if (direction === 'word_forward') {
-      return this._executeWordForward();
+      return this._executeWordMotion('w', WordMotion.findNextWordStart);
+    }
+    if (direction === 'word_end') {
+      return this._executeWordMotion('e', WordMotion.findNextWordEnd);
     }
 
     const currentPosition = this._gameState.cursor.position;
@@ -56,8 +59,11 @@ export class MovePlayerUseCase {
     return this._finalizeMove(newPosition);
   }
 
-  async _executeWordForward() {
-    if (!this._hasWordKey()) {
+  // Shared driver for word-based motions (vim 'w', 'e'). The strategy parameter
+  // picks WHICH word-position to land on (start vs end). Required key is the
+  // vim-key letter the player must have collected to use this motion.
+  async _executeWordMotion(requiredKey, findTarget) {
+    if (!this._hasCollectedKey(requiredKey)) {
       return { success: false, reason: 'word_motion_locked' };
     }
 
@@ -73,7 +79,7 @@ export class MovePlayerUseCase {
     }
 
     const isWalkable = (pos) => this._isWalkableForWordMotion(pos);
-    const target = WordMotion.findNextWordStart(cursorPos, labels, isWalkable);
+    const target = findTarget(cursorPos, labels, isWalkable);
     if (!target) {
       return { success: false, reason: 'no_next_word' };
     }
@@ -181,7 +187,11 @@ export class MovePlayerUseCase {
   }
 
   _hasWordKey() {
-    return this._gameState.collectedKeys.has('w');
+    return this._hasCollectedKey('w');
+  }
+
+  _hasCollectedKey(key) {
+    return this._gameState.collectedKeys.has(key);
   }
 
   _isPositionWalkable(position, direction = null) {

--- a/src/application/use-cases/MovePlayerUseCase.js
+++ b/src/application/use-cases/MovePlayerUseCase.js
@@ -200,8 +200,9 @@ export class MovePlayerUseCase {
 
   // Side-effect-free walkability predicate used by the WordMotion flood-fill.
   // Mirrors _checkWalkability but never triggers tryUnlockSecondaryGate (which
-  // would consume collected keys), and treats rocks as jumpable so 'w' can hop
-  // over them even though h/j/k/l cannot step on them.
+  // would consume collected keys). Word motions (w, e) can hop over rocks AND
+  // walls — but water (and any other non-walkable tile not in this list) stays
+  // a hard border between text groups.
   _isWalkableForWordMotion(position) {
     if (typeof this._gameState.getGate === 'function') {
       const gate = this._gameState.getGate();
@@ -218,7 +219,7 @@ export class MovePlayerUseCase {
     }
     if (this._gameState.map.isWalkable(position)) return true;
     const tile = this._gameState.map.getTileAt(position);
-    return !!(tile && tile.name === 'rock');
+    return !!(tile && (tile.name === 'rock' || tile.name === 'wall'));
   }
 
   _isRampMovementAllowed(targetPosition, direction) {

--- a/src/domain/services/WordMotion.js
+++ b/src/domain/services/WordMotion.js
@@ -1,6 +1,6 @@
 import { Position } from '../value-objects/Position.js';
 
-// Vim 'w' word definition: a "word" is a maximal run of [A-Za-z0-9_],
+// Vim 'w' / 'e' word definition: a "word" is a maximal run of [A-Za-z0-9_],
 // OR a maximal run of non-blank non-word chars. A class change without a gap
 // also starts a new word (so "time," yields two words: "time" and ",").
 //
@@ -15,26 +15,34 @@ import { Position } from '../value-objects/Position.js';
 // remain hard borders even within a group.
 export const WordMotion = {
   findNextWordStart(cursor, textLabels, isWalkable = null) {
-    if (!textLabels || textLabels.length === 0) return null;
+    return findNext(cursor, textLabels, isWalkable, collectWordStarts);
+  },
 
-    const cursorLabel = textLabels.find((l) => l.position.equals(cursor));
-    const cursorGroup = cursorLabel ? (cursorLabel.group ?? null) : null;
-    const eligibleLabels = textLabels.filter((l) => (l.group ?? null) === cursorGroup);
-
-    const candidates = collectCandidates(cursor, eligibleLabels);
-    if (candidates.length === 0) return null;
-
-    if (!isWalkable) return candidates[0];
-
-    const reachable = computeReachable(cursor, eligibleLabels, isWalkable);
-    for (const target of candidates) {
-      if (reachable.has(keyOf(target))) return target;
-    }
-    return null;
+  findNextWordEnd(cursor, textLabels, isWalkable = null) {
+    return findNext(cursor, textLabels, isWalkable, collectWordEnds);
   },
 };
 
-function collectCandidates(cursor, textLabels) {
+function findNext(cursor, textLabels, isWalkable, xExtractor) {
+  if (!textLabels || textLabels.length === 0) return null;
+
+  const cursorLabel = textLabels.find((l) => l.position.equals(cursor));
+  const cursorGroup = cursorLabel ? (cursorLabel.group ?? null) : null;
+  const eligibleLabels = textLabels.filter((l) => (l.group ?? null) === cursorGroup);
+
+  const candidates = collectCandidates(cursor, eligibleLabels, xExtractor);
+  if (candidates.length === 0) return null;
+
+  if (!isWalkable) return candidates[0];
+
+  const reachable = computeReachable(cursor, eligibleLabels, isWalkable);
+  for (const target of candidates) {
+    if (reachable.has(keyOf(target))) return target;
+  }
+  return null;
+}
+
+function collectCandidates(cursor, textLabels, xExtractor) {
   const byRow = new Map();
   for (const label of textLabels) {
     const y = label.position.y;
@@ -47,9 +55,9 @@ function collectCandidates(cursor, textLabels) {
 
   for (const y of forwardRows) {
     const sortedLabels = byRow.get(y).sort((a, b) => a.position.x - b.position.x);
-    for (const startX of collectWordStarts(sortedLabels)) {
-      if (y === cursor.y && startX <= cursor.x) continue;
-      result.push(new Position(startX, y));
+    for (const x of xExtractor(sortedLabels)) {
+      if (y === cursor.y && x <= cursor.x) continue;
+      result.push(new Position(x, y));
     }
   }
 
@@ -116,6 +124,24 @@ function collectWordStarts(sortedRowLabels) {
     prevClass = cls;
   }
   return starts;
+}
+
+function collectWordEnds(sortedRowLabels) {
+  const ends = [];
+  let prevX = null;
+  let prevClass = null;
+  let currentEnd = null;
+  for (const label of sortedRowLabels) {
+    const x = label.position.x;
+    const cls = charClass(label.text);
+    const continues = prevX !== null && x === prevX + 1 && cls === prevClass;
+    if (!continues && currentEnd !== null) ends.push(currentEnd);
+    currentEnd = x;
+    prevX = x;
+    prevClass = cls;
+  }
+  if (currentEnd !== null) ends.push(currentEnd);
+  return ends;
 }
 
 function keyOf(pos) {

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -429,6 +429,7 @@ export class BlinkingGroveZone {
 
               { text: ':', position: [30, 9], color: '#ffa726', fontSize: '14px', group: 'vim_secret_aside' },
               { text: ')', position: [31, 9], color: '#ffa726', fontSize: '14px', group: 'vim_secret_aside' },
+              { text: ')', position: [35, 9], color: '#ffa726', fontSize: '14px', group: 'vim_secret_aside' },
             ],
             specialTiles: [
               // Three keys positioned near the letters for the three gates

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -429,7 +429,7 @@ export class BlinkingGroveZone {
 
               { text: ':', position: [30, 9], color: '#ffa726', fontSize: '14px', group: 'vim_secret_aside' },
               { text: ')', position: [31, 9], color: '#ffa726', fontSize: '14px', group: 'vim_secret_aside' },
-              { text: ')', position: [35, 9], color: '#ffa726', fontSize: '14px', group: 'vim_secret_aside' },
+              { text: '.', position: [35, 9], color: '#ffa726', fontSize: '14px', group: 'vim_secret_aside' },
             ],
             specialTiles: [
               // Three keys positioned near the letters for the three gates

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -436,7 +436,7 @@ export class BlinkingGroveZone {
               { type: 'collectible_key', keyId: 'silver_key', name: 'Silver Key', color: '#C0C0C0', position: [33, 9] }, // Next to 'l' in 'Total'
               { type: 'collectible_key', keyId: 'bronze_key', name: 'Bronze Key', color: '#CD7F32', position: [26, 0] }, // Next to 'z' in 'Rulez'
               { type: 'vim_key', value: 'w', position: [6, 3], description: 'w - jump forward to next word' },
-              { type: 'vim_key', value: 'e', position: [12, 9], description: 'e - jump to end of word' },
+              { type: 'vim_key', value: 'e', position: [11, 8], description: 'e - jump to end of word' },
             ],
             // Player starts here when entering the hidden area (just inside from the gate)
             playerStartPosition: [0, 0], // Just inside the hidden area, right after the connection

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -436,6 +436,7 @@ export class BlinkingGroveZone {
               { type: 'collectible_key', keyId: 'silver_key', name: 'Silver Key', color: '#C0C0C0', position: [33, 9] }, // Next to 'l' in 'Total'
               { type: 'collectible_key', keyId: 'bronze_key', name: 'Bronze Key', color: '#CD7F32', position: [26, 0] }, // Next to 'z' in 'Rulez'
               { type: 'vim_key', value: 'w', position: [6, 3], description: 'w - jump forward to next word' },
+              { type: 'vim_key', value: 'e', position: [12, 9], description: 'e - jump to end of word' },
             ],
             // Player starts here when entering the hidden area (just inside from the gate)
             playerStartPosition: [0, 0], // Just inside the hidden area, right after the connection

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -136,19 +136,19 @@ export class BlinkingGroveZone {
             id: 'vim_secret_area',
             revealWhen: 'escProgression',
             layout: [
-              'DWWWWWWWWWWWWWWWPPPPPPPPPPPPPPPPPPPPWWWWWWWWWWWWWWWW',
+              'DWWWWWWWWWWWWWWWPPPRPPPPRPPRPPPPPPPPWWWWWWWWWWWWWWWW',
               'PWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
               'PDWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
               'PPPPPRPPPPPPPPPRPPPPPPPWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
               'PPPPPPRPPPPPPPPPPPPPRPPPPPPPPPPPWWWDWWWWWWWWWWWWWWWW',
               'PPPPPPPPRPPPPPPPPPPPPPRPPPPPWWWWWWWDWWWWWWWWWWWWWWWW',
-              'PPPRPPPRPPPPPPPPRPPRPPPPPPWWWWWWWWWDWWWWWWWWWWWWWWWW',
-              'PPPPRPRPRPPPPPPPPPWWWWWWWWWWWWPPPPPPWWWWWWWWWWWWWWWW',
-              'PPPRPPPPRPPPRPPPPPPPPPWWWWWWWWPPPPPPWWWWWWWWWWWWWWWW',
-              'PRPPPPPPPRPPPRPPPPPPPPPWWWWWWWPPPPPPWWWWWWWWWWWWWWWW',
-              'PPRPPPPPPPRPPPRPPPRPPPPPPWWWWWWWWWWDWWWWWWWWWWWWWWWW',
-              'PPPPRPPPRPPPRPPWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
-              'PPPRPPPRPPPPPRPPRPPPRPPPPRPPPPPPPPPDWWWWWWWWWWWWWWWW',
+              'PPPPPPPRPPPPPPPPRPPRPPPPPWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+              'PRPPPPPPRRRRPPPPRWWWWWWWWWWWWWPPPPPPWWWWWWWWWWWWWWWW',
+              'PPPRPPPPRPPPRPPPPPPPPWWWWWWWWWPPPPPRWWWWWWWWWWWWWWWW',
+              'PPPPPPPPPRPPPRPPPPPPPPWWWWWWWWPPPPRPWWWWWWWWWWWWWWWW',
+              'PPRPPPPPPPRPPPRPPPPPPPPPWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+              'PRPPPPPPPPPRRRWWWWWWWWWWWWWWWWWWWWWDWWWWWWWWWWWWWWWW',
+              'PPPPPPPRPPPPPPPPPPPPRPPPPRPPPPPPPPPDWWWWWWWWWWWWWWWW',
               'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWGWWWWWWWWWWWWWWWWW',
               'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWGWWWWWWWWWWWWWWWWW',
               'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWGWWWWWWWWWWWWWWWWW',
@@ -175,17 +175,18 @@ export class BlinkingGroveZone {
               { text: 'o', position: [21, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
               { text: 't', position: [22, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
               { text: 'a', position: [23, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
-              { text: 'l', position: [24, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
 
-              { text: 'R', position: [26, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
-              { text: 'u', position: [27, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
-              { text: 'l', position: [28, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
-              { text: 'e', position: [29, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
-              { text: 'z', position: [30, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: 'l', position: [25, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: 'y', position: [26, 0], color: '#4ecdc4', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
 
-              { text: '!', position: [32, 0], color: '#f7dc6f', fontSize: '24px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: 'R', position: [28, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: 'u', position: [29, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: 'l', position: [30, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: 'e', position: [31, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: 'z', position: [32, 0], color: '#45b7d1', fontSize: '20px', fontWeight: 'bold', group: 'vim_secret_header' },
               { text: '!', position: [33, 0], color: '#f7dc6f', fontSize: '24px', fontWeight: 'bold', group: 'vim_secret_header' },
               { text: '!', position: [34, 0], color: '#f7dc6f', fontSize: '24px', fontWeight: 'bold', group: 'vim_secret_header' },
+              { text: '!', position: [35, 0], color: '#f7dc6f', fontSize: '24px', fontWeight: 'bold', group: 'vim_secret_header' },
 
               // Additional encouraging text
               { text: 'T', position: [0, 3], color: '#95e1d3', fontSize: '16px', group: 'vim_secret_poem' },
@@ -431,9 +432,9 @@ export class BlinkingGroveZone {
             ],
             specialTiles: [
               // Three keys positioned near the letters for the three gates
-              { type: 'collectible_key', keyId: 'golden_key', name: 'Golden Key', color: '#FFD700', position: [19, 0] }, // Next to 'm' in 'vim'
-              { type: 'collectible_key', keyId: 'silver_key', name: 'Silver Key', color: '#C0C0C0', position: [25, 0] }, // Next to 'l' in 'Total'
-              { type: 'collectible_key', keyId: 'bronze_key', name: 'Bronze Key', color: '#CD7F32', position: [31, 0] }, // Next to 'z' in 'Rulez'
+              { type: 'collectible_key', keyId: 'golden_key', name: 'Golden Key', color: '#FFD700', position: [12, 9] }, // Next to 'm' in 'vim'
+              { type: 'collectible_key', keyId: 'silver_key', name: 'Silver Key', color: '#C0C0C0', position: [33, 9] }, // Next to 'l' in 'Total'
+              { type: 'collectible_key', keyId: 'bronze_key', name: 'Bronze Key', color: '#CD7F32', position: [26, 0] }, // Next to 'z' in 'Rulez'
               { type: 'vim_key', value: 'w', position: [6, 3], description: 'w - jump forward to next word' },
             ],
             // Player starts here when entering the hidden area (just inside from the gate)

--- a/src/infrastructure/input/KeyboardInputHandler.js
+++ b/src/infrastructure/input/KeyboardInputHandler.js
@@ -54,7 +54,8 @@ export class KeyboardInputHandler extends InputHandler {
             'h': 'left',
             'arrowright': 'right',
             'l': 'right',
-            'w': 'word_forward'
+            'w': 'word_forward',
+            'e': 'word_end'
         };
 
         return keyMappings[key] || null;

--- a/tests/application/use-cases/MovePlayerUseCase.test.js
+++ b/tests/application/use-cases/MovePlayerUseCase.test.js
@@ -257,6 +257,97 @@ describe('MovePlayerUseCase', () => {
       });
     });
 
+    describe("word_end (vim 'e' motion)", () => {
+      const labelAt = (x, y, text) => ({ position: new Position(x, y), text });
+      // Cursor starts at (5, 5) and sits on the start of a 3-letter word "abc"
+      // at cols 5..7, gap at col 8, then "de" at cols 9..10.
+      const wordRow = [
+        labelAt(5, 5, 'a'), labelAt(6, 5, 'b'), labelAt(7, 5, 'c'),
+        labelAt(9, 5, 'd'), labelAt(10, 5, 'e'),
+      ];
+
+      it('does nothing when e key has not been collected', async () => {
+        mockGameState.collectedKeys = new Set();
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(wordRow);
+
+        const result = await movePlayerUseCase.execute('word_end');
+
+        expect(mockGameState.cursor.position.x).toBe(5);
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('word_motion_locked');
+      });
+
+      it('does nothing when there are no text labels in the zone', async () => {
+        mockGameState.collectedKeys = new Set(['e']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue([]);
+
+        const result = await movePlayerUseCase.execute('word_end');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('no_text');
+      });
+
+      it('does nothing when the cursor is not on a text label', async () => {
+        mockGameState.collectedKeys = new Set(['e']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue([
+          labelAt(0, 5, 'x'), labelAt(9, 5, 'y'),
+        ]);
+
+        const result = await movePlayerUseCase.execute('word_end');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('not_on_text');
+        expect(mockGameState.cursor.position.x).toBe(5);
+      });
+
+      it('jumps cursor to the end of the current word', async () => {
+        mockGameState.collectedKeys = new Set(['e']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(wordRow);
+
+        const result = await movePlayerUseCase.execute('word_end');
+
+        expect(result.success).toBe(true);
+        expect(mockGameState.cursor.position.x).toBe(7);
+        expect(mockGameState.cursor.position.y).toBe(5);
+      });
+
+      it('jumps to the end of the next word when cursor is already at end of current', async () => {
+        mockGameState.collectedKeys = new Set(['e']);
+        mockGameState.cursor = new Cursor(new Position(7, 5)); // last char of "abc"
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(wordRow);
+
+        const result = await movePlayerUseCase.execute('word_end');
+
+        expect(result.success).toBe(true);
+        expect(mockGameState.cursor.position.x).toBe(10);
+        expect(mockGameState.cursor.position.y).toBe(5);
+      });
+
+      it('returns no_next_word when there are no further word ends', async () => {
+        mockGameState.collectedKeys = new Set(['e']);
+        mockGameState.cursor = new Cursor(new Position(10, 5)); // last char of last word
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(wordRow);
+
+        const result = await movePlayerUseCase.execute('word_end');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('no_next_word');
+      });
+
+      it('does not unlock secondary gates as a side effect of the flood-fill', async () => {
+        mockGameState.collectedKeys = new Set(['e']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(wordRow);
+        mockGameState.getSecondaryGates = jest.fn().mockReturnValue([
+          { position: new Position(8, 5), isWalkable: jest.fn().mockReturnValue(false) },
+        ]);
+        mockGameState.tryUnlockSecondaryGate = jest.fn().mockReturnValue(true);
+
+        await movePlayerUseCase.execute('word_end');
+
+        expect(mockGameState.tryUnlockSecondaryGate).not.toHaveBeenCalled();
+      });
+    });
+
     it('should collect key when moving to key position', async () => {
       const key = new VimKey(new Position(6, 5), 'h', 'Move left');
       mockGameState.availableKeys = [key];

--- a/tests/application/use-cases/MovePlayerUseCase.test.js
+++ b/tests/application/use-cases/MovePlayerUseCase.test.js
@@ -184,20 +184,47 @@ describe('MovePlayerUseCase', () => {
         expect(mockGameState.tryUnlockSecondaryGate).not.toHaveBeenCalled();
       });
 
-      it('jumps over a rock tile (rocks are passable for w-motion but not for h/j/k/l)', async () => {
+      it('jumps over a full rock column (rocks are passable for w-motion)', async () => {
         mockGameState.collectedKeys = new Set(['w']);
         mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
-        // (6, 5) is a rock — non-walkable to step-by-step movement but jumpable for w-motion.
-        mockMap.isWalkable.mockImplementation((pos) => !(pos.x === 6 && pos.y === 5));
+        // Entire column 6 is rock — a true barrier that BFS cannot detour around.
+        mockMap.isWalkable.mockImplementation((pos) => pos.x !== 6);
         mockMap.getTileAt.mockImplementation((pos) =>
-          pos.x === 6 && pos.y === 5 ? { name: 'rock', walkable: false } : { name: 'grass' }
+          pos.x === 6 ? { name: 'rock', walkable: false } : { name: 'grass' }
         );
 
         const result = await movePlayerUseCase.execute('word_forward');
 
         expect(result.success).toBe(true);
         expect(mockGameState.cursor.position.x).toBe(7);
-        expect(mockGameState.cursor.position.y).toBe(5);
+      });
+
+      it('jumps over a full wall column (walls are passable for w-motion)', async () => {
+        mockGameState.collectedKeys = new Set(['w']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+        mockMap.isWalkable.mockImplementation((pos) => pos.x !== 6);
+        mockMap.getTileAt.mockImplementation((pos) =>
+          pos.x === 6 ? { name: 'wall', walkable: false } : { name: 'grass' }
+        );
+
+        const result = await movePlayerUseCase.execute('word_forward');
+
+        expect(result.success).toBe(true);
+        expect(mockGameState.cursor.position.x).toBe(7);
+      });
+
+      it('refuses to jump across a full water column (water is a hard border)', async () => {
+        mockGameState.collectedKeys = new Set(['w']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+        mockMap.isWalkable.mockImplementation((pos) => pos.x !== 6);
+        mockMap.getTileAt.mockImplementation((pos) =>
+          pos.x === 6 ? { name: 'water', walkable: false } : { name: 'grass' }
+        );
+
+        const result = await movePlayerUseCase.execute('word_forward');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('no_next_word');
       });
 
       it('routes around an isolated non-walkable tile and reaches the next word', async () => {

--- a/tests/domain/services/WordMotion.test.js
+++ b/tests/domain/services/WordMotion.test.js
@@ -157,3 +157,79 @@ describe('WordMotion.findNextWordStart', () => {
     });
   });
 });
+
+describe('WordMotion.findNextWordEnd', () => {
+  it('returns null for empty text labels', () => {
+    expect(WordMotion.findNextWordEnd(new Position(0, 0), [])).toBeNull();
+    expect(WordMotion.findNextWordEnd(new Position(0, 0), null)).toBeNull();
+  });
+
+  it('jumps from the start of a word to the end of the same word', () => {
+    const labels = [
+      label(0, 3, 'T'), label(1, 3, 'h'), label(2, 3, 'e'),
+      label(4, 3, 'c'), label(5, 3, 'a'), label(6, 3, 't'),
+    ];
+    const target = WordMotion.findNextWordEnd(new Position(0, 3), labels);
+    expect(target).toEqual(new Position(2, 3));
+  });
+
+  it('jumps from the middle of a word to the end of the same word', () => {
+    const labels = [
+      label(0, 3, 'T'), label(1, 3, 'h'), label(2, 3, 'e'),
+      label(4, 3, 'c'), label(5, 3, 'a'), label(6, 3, 't'),
+    ];
+    const target = WordMotion.findNextWordEnd(new Position(1, 3), labels);
+    expect(target).toEqual(new Position(2, 3));
+  });
+
+  it('jumps from the end of a word to the end of the next word', () => {
+    const labels = [
+      label(0, 3, 'T'), label(1, 3, 'h'), label(2, 3, 'e'),
+      label(4, 3, 'c'), label(5, 3, 'a'), label(6, 3, 't'),
+    ];
+    const target = WordMotion.findNextWordEnd(new Position(2, 3), labels);
+    expect(target).toEqual(new Position(6, 3));
+  });
+
+  it('treats punctuation as a separate word with its own end', () => {
+    const labels = [
+      label(0, 3, 'h'), label(1, 3, 'i'), label(2, 3, '!'),
+    ];
+    const target = WordMotion.findNextWordEnd(new Position(0, 3), labels);
+    expect(target).toEqual(new Position(1, 3));
+  });
+
+  it('wraps to the next row when no more word ends remain on current row', () => {
+    const labels = [
+      label(0, 3, 'a'),
+      label(0, 5, 'b'), label(1, 5, 'c'),
+    ];
+    const target = WordMotion.findNextWordEnd(new Position(0, 3), labels);
+    expect(target).toEqual(new Position(1, 5));
+  });
+
+  it('returns null when no further word ends exist', () => {
+    const labels = [label(0, 3, 'a')];
+    expect(WordMotion.findNextWordEnd(new Position(0, 3), labels)).toBeNull();
+  });
+
+  it('only considers labels in the same group as the cursor', () => {
+    const labels = [
+      label(0, 3, 'a', 'poem'),
+      label(5, 3, 'b', 'aside'),
+      label(10, 3, 'c', 'poem'), label(11, 3, 'd', 'poem'),
+    ];
+    const target = WordMotion.findNextWordEnd(new Position(0, 3), labels);
+    expect(target).toEqual(new Position(11, 3));
+  });
+
+  it('refuses to jump when target is unreachable via the walkability predicate', () => {
+    const labels = [
+      label(0, 3, 'a'),
+      label(5, 3, 'b'), label(6, 3, 'c'),
+    ];
+    const isWalkable = (pos) => pos.x !== 3;
+    const target = WordMotion.findNextWordEnd(new Position(0, 3), labels, isWalkable);
+    expect(target).toBeNull();
+  });
+});

--- a/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
+++ b/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
@@ -102,11 +102,11 @@ describe('BlinkingGroveZone', () => {
       const hiddenVimKeys = hiddenArea.specialTiles.filter(tile => tile.type === 'vim_key');
       expect(hiddenVimKeys.map(k => k.value)).toContain('w');
 
-      // The 'e' (end-of-word motion) vim_key sits on the 'e' of "one" in the
-      // "A shadowy one emerges," poem line (hidden-area coords [12, 9]).
+      // The 'e' (end-of-word motion) vim_key sits on the 'e' of "the" in the
+      // "But from the shadows," poem line (hidden-area coords [11, 8]).
       expect(hiddenVimKeys.map(k => k.value)).toContain('e');
       const eKey = hiddenVimKeys.find(k => k.value === 'e');
-      expect(eKey.position).toEqual([12, 9]);
+      expect(eKey.position).toEqual([11, 8]);
     });
 
     test('should have correct text labels configuration', () => {

--- a/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
+++ b/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
@@ -101,6 +101,12 @@ describe('BlinkingGroveZone', () => {
       // Verify the word-motion vim_key is also present (power-up that lets the player walk over rocks)
       const hiddenVimKeys = hiddenArea.specialTiles.filter(tile => tile.type === 'vim_key');
       expect(hiddenVimKeys.map(k => k.value)).toContain('w');
+
+      // The 'e' (end-of-word motion) vim_key sits on the 'e' of "one" in the
+      // "A shadowy one emerges," poem line (hidden-area coords [12, 9]).
+      expect(hiddenVimKeys.map(k => k.value)).toContain('e');
+      const eKey = hiddenVimKeys.find(k => k.value === 'e');
+      expect(eKey.position).toEqual([12, 9]);
     });
 
     test('should have correct text labels configuration', () => {


### PR DESCRIPTION
## Summary

- Adds the `e` vim key to the Blinking Grove hidden area, sitting on the 'e' of "the" in "But from the shadows," (`[11, 8]`). Collecting it unlocks vim's end-of-word motion: cursor jumps to the end of the current word, or end of the next word if already at end of current.
- Extends `WordMotion` with a parameterised `findNextWordEnd` twin of `findNextWordStart`. Both share the same group filtering, flood-fill walkability, and cross-row wrap.
- Generalises `MovePlayerUseCase` to a shared `_executeWordMotion(requiredKey, findTarget)` driver — the existing `w` flow now goes through it too.
- Word motions (w, e) can jump over **rocks AND walls** in addition to walkable tiles. Water remains a hard border.
- Includes a chore commit that preserves in-progress hidden-area layout edits (Totaly header, rock redistribution, collectible-key relocations).

## Test plan

- [x] `WordMotion.findNextWordEnd` — 9 new unit tests (start/middle/end of word, punctuation, row-wrap, group filter, walkability)
- [x] `MovePlayerUseCase` `word_end` flow — 6 new tests (locked without key, no text, not-on-text, jump-to-end, end-to-next-end, no-next-end)
- [x] `MovePlayerUseCase` flood-fill no-side-effect — `tryUnlockSecondaryGate` is never called during `word_end`
- [x] `MovePlayerUseCase` barrier tests — full-column rock / wall / water barriers (rock & wall jumpable, water not)
- [x] Zone test — `e` vim_key present at `[11, 8]`
- [x] All 1741 tests pass; build clean