### PR TITLE
feat: b vim key (word-backward motion)

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,13 +115,15 @@
 
         // Level toggle is handled by LevelSelectorUI (auto-hide + title click)
       </script>
-      <div class="collected-keys" id="collectedKeys">
-        <h3>Collected Keys:</h3>
-        <div class="key-display"></div>
-      </div>
-      <div class="collectible-inventory" id="collectibleInventory">
-        <h3>Key Inventory:</h3>
-        <div class="collectible-display"></div>
+      <div class="bottom-ui-bar">
+        <div class="collected-keys" id="collectedKeys">
+          <h3>Collected Keys:</h3>
+          <div class="key-display"></div>
+        </div>
+        <div class="collectible-inventory" id="collectibleInventory">
+          <h3>Key Inventory:</h3>
+          <div class="collectible-display"></div>
+        </div>
       </div>
     </div>
     <script type="module" src="src/main.js"></script>

--- a/src/VimForKidsGame.js
+++ b/src/VimForKidsGame.js
@@ -120,7 +120,8 @@ export class VimForKidsGame {
           levelConfig,
           this.currentGameId,
           this.cutsceneService,
-          this.cutsceneRenderer
+          this.cutsceneRenderer,
+          { initialCollectedKeys: this._carriedCollectedKeys || null }
         );
       } catch (error) {
         // Fallback to textland game state
@@ -335,6 +336,12 @@ export class VimForKidsGame {
 
     // Show level cutscene if applicable
     await this._showLevelCutsceneIfNeeded(this.currentGameId, newLevelId);
+
+    // Capture vim keys collected so far so they persist into the next level.
+    this._carriedCollectedKeys =
+      this.gameState && this.gameState.collectedKeys
+        ? new Set(this.gameState.collectedKeys)
+        : null;
 
     // Clean up current game state
     this.cleanup();

--- a/src/application/LevelGameState.js
+++ b/src/application/LevelGameState.js
@@ -7,7 +7,8 @@ export class LevelGameState {
     levelConfig,
     gameId = null,
     cutsceneService = null,
-    cutsceneRenderer = null
+    cutsceneRenderer = null,
+    options = {}
   ) {
     if (!zoneProvider || !levelConfig) {
       throw new Error('LevelGameState requires zoneProvider and levelConfig');
@@ -27,6 +28,12 @@ export class LevelGameState {
 
     // Track ESC progression for special zones
     this._escProgressionPressed = new Set();
+
+    // Vim keys collected on earlier levels persist into this one. Defensive copy
+    // so callers can't mutate our internal set after construction.
+    this._initialCollectedKeys = options.initialCollectedKeys
+      ? new Set(options.initialCollectedKeys)
+      : null;
 
     // Initialize first zone synchronously for backward compatibility
     this._loadZoneSync(this._getCurrentZoneId());
@@ -52,7 +59,9 @@ export class LevelGameState {
       this.map = this.zone.gameMap;
       this.cursor = new Cursor(this.zone.getCursorStartPosition());
       this.availableCollectibleKeys = this.zone.collectibleKeys;
-      this.collectedKeys = new Set();
+      this.collectedKeys = this._initialCollectedKeys
+        ? new Set(this._initialCollectedKeys)
+        : new Set();
       this.collectedCollectibleKeys = new Set();
     } catch (error) {
       throw new Error(`Zone '${zoneId}' not found in registry`);

--- a/src/application/use-cases/MovePlayerUseCase.js
+++ b/src/application/use-cases/MovePlayerUseCase.js
@@ -22,6 +22,9 @@ export class MovePlayerUseCase {
     if (direction === 'word_end') {
       return this._executeWordMotion('e', WordMotion.findNextWordEnd);
     }
+    if (direction === 'word_backward') {
+      return this._executeWordMotion('b', WordMotion.findPreviousWordStart);
+    }
 
     const currentPosition = this._gameState.cursor.position;
     const newPosition = this._calculateNewPosition(currentPosition, direction);

--- a/src/domain/services/WordMotion.js
+++ b/src/domain/services/WordMotion.js
@@ -15,22 +15,26 @@ import { Position } from '../value-objects/Position.js';
 // remain hard borders even within a group.
 export const WordMotion = {
   findNextWordStart(cursor, textLabels, isWalkable = null) {
-    return findNext(cursor, textLabels, isWalkable, collectWordStarts);
+    return findInDirection(cursor, textLabels, isWalkable, collectWordStarts, 'forward');
   },
 
   findNextWordEnd(cursor, textLabels, isWalkable = null) {
-    return findNext(cursor, textLabels, isWalkable, collectWordEnds);
+    return findInDirection(cursor, textLabels, isWalkable, collectWordEnds, 'forward');
+  },
+
+  findPreviousWordStart(cursor, textLabels, isWalkable = null) {
+    return findInDirection(cursor, textLabels, isWalkable, collectWordStarts, 'backward');
   },
 };
 
-function findNext(cursor, textLabels, isWalkable, xExtractor) {
+function findInDirection(cursor, textLabels, isWalkable, xExtractor, direction) {
   if (!textLabels || textLabels.length === 0) return null;
 
   const cursorLabel = textLabels.find((l) => l.position.equals(cursor));
   const cursorGroup = cursorLabel ? (cursorLabel.group ?? null) : null;
   const eligibleLabels = textLabels.filter((l) => (l.group ?? null) === cursorGroup);
 
-  const candidates = collectCandidates(cursor, eligibleLabels, xExtractor);
+  const candidates = collectCandidates(cursor, eligibleLabels, xExtractor, direction);
   if (candidates.length === 0) return null;
 
   if (!isWalkable) return candidates[0];
@@ -42,7 +46,7 @@ function findNext(cursor, textLabels, isWalkable, xExtractor) {
   return null;
 }
 
-function collectCandidates(cursor, textLabels, xExtractor) {
+function collectCandidates(cursor, textLabels, xExtractor, direction) {
   const byRow = new Map();
   for (const label of textLabels) {
     const y = label.position.y;
@@ -50,13 +54,21 @@ function collectCandidates(cursor, textLabels, xExtractor) {
     byRow.get(y).push(label);
   }
 
-  const forwardRows = [...byRow.keys()].filter((y) => y >= cursor.y).sort((a, b) => a - b);
+  const forward = direction === 'forward';
+  const rowsInDir = [...byRow.keys()]
+    .filter((y) => (forward ? y >= cursor.y : y <= cursor.y))
+    .sort((a, b) => (forward ? a - b : b - a));
   const result = [];
 
-  for (const y of forwardRows) {
+  for (const y of rowsInDir) {
     const sortedLabels = byRow.get(y).sort((a, b) => a.position.x - b.position.x);
-    for (const x of xExtractor(sortedLabels)) {
-      if (y === cursor.y && x <= cursor.x) continue;
+    const xs = xExtractor(sortedLabels);
+    const orderedXs = forward ? xs : [...xs].reverse();
+    for (const x of orderedXs) {
+      if (y === cursor.y) {
+        if (forward && x <= cursor.x) continue;
+        if (!forward && x >= cursor.x) continue;
+      }
       result.push(new Position(x, y));
     }
   }

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -438,6 +438,7 @@ export class BlinkingGroveZone {
               { type: 'collectible_key', keyId: 'bronze_key', name: 'Bronze Key', color: '#CD7F32', position: [26, 0] }, // Next to 'z' in 'Rulez'
               { type: 'vim_key', value: 'w', position: [6, 3], description: 'w - jump forward to next word' },
               { type: 'vim_key', value: 'e', position: [11, 8], description: 'e - jump to end of word' },
+              { type: 'vim_key', value: 'b', position: [35, 12], description: 'b - jump backward to start of word' },
             ],
             // Player starts here when entering the hidden area (just inside from the gate)
             playerStartPosition: [0, 0], // Just inside the hidden area, right after the connection

--- a/src/infrastructure/input/KeyboardInputHandler.js
+++ b/src/infrastructure/input/KeyboardInputHandler.js
@@ -55,7 +55,8 @@ export class KeyboardInputHandler extends InputHandler {
             'arrowright': 'right',
             'l': 'right',
             'w': 'word_forward',
-            'e': 'word_end'
+            'e': 'word_end',
+            'b': 'word_backward'
         };
 
         return keyMappings[key] || null;

--- a/src/infrastructure/rendering/VimKeyInfo.js
+++ b/src/infrastructure/rendering/VimKeyInfo.js
@@ -185,7 +185,7 @@ export class VimKeyInfo {
 
         const desc = document.createElement('span');
         desc.className = 'help-key-label';
-        desc.textContent = info.desc.split('.')[0];
+        desc.textContent = info.shortLabel || info.desc.split('.')[0];
 
         row.appendChild(badge);
         row.appendChild(desc);
@@ -223,7 +223,8 @@ export class VimKeyInfo {
     },
     w: {
       category: 'Word Jump',
-      desc: 'Jump forward',
+      desc: 'Jumps your character forward to the START of the next word.',
+      shortLabel: 'Jump forward',
       example: 'the [c]at sat \u2192 press w \u2192 the cat [s]at',
     },
     W: {
@@ -233,7 +234,8 @@ export class VimKeyInfo {
     },
     e: {
       category: 'Word Jump',
-      desc: 'Jump end',
+      desc: 'Jumps your character to the END of the current or next word.',
+      shortLabel: 'Jump end',
       example: '[t]he cat \u2192 press e \u2192 th[e] cat',
     },
     E: {
@@ -243,7 +245,8 @@ export class VimKeyInfo {
     },
     b: {
       category: 'Word Jump',
-      desc: 'Jump back',
+      desc: 'Jumps your character BACK to the start of the previous word.',
+      shortLabel: 'Jump back',
       example: 'the ca[t] \u2192 press b \u2192 the [c]at',
     },
     B: {

--- a/src/infrastructure/rendering/VimKeyInfo.js
+++ b/src/infrastructure/rendering/VimKeyInfo.js
@@ -223,7 +223,7 @@ export class VimKeyInfo {
     },
     w: {
       category: 'Word Jump',
-      desc: 'Jump forward.',
+      desc: 'Jump forward',
       example: 'the [c]at sat \u2192 press w \u2192 the cat [s]at',
     },
     W: {
@@ -233,7 +233,7 @@ export class VimKeyInfo {
     },
     e: {
       category: 'Word Jump',
-      desc: 'Your character jumps to the END of the current or next word.',
+      desc: 'Jump end',
       example: '[t]he cat \u2192 press e \u2192 th[e] cat',
     },
     E: {
@@ -243,7 +243,7 @@ export class VimKeyInfo {
     },
     b: {
       category: 'Word Jump',
-      desc: 'Your character jumps BACK to the start of the previous word!',
+      desc: 'Jump back',
       example: 'the ca[t] \u2192 press b \u2192 the [c]at',
     },
     B: {

--- a/style.css
+++ b/style.css
@@ -1136,16 +1136,26 @@ h1 {
 }
 
 /* UI Elements — Neo-brutalist kids-friendly style */
+
+/* Bottom HUD bar — flex container so the two panels grow naturally without
+   overlapping each other as the player collects more keys. */
+.bottom-ui-bar {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  z-index: 1000;
+  max-width: calc(100% - 32px);
+}
+
 .collected-keys {
   margin: 0;
   padding: 10px 12px;
   background-color: #ffffff;
   border-radius: 10px;
   border: 3px solid #1a1a2e;
-  position: absolute;
-  bottom: 16px;
-  left: 16px;
-  z-index: 1000;
   font-size: 12px;
   height: 80px;
   box-sizing: border-box;
@@ -1205,10 +1215,6 @@ h1 {
   background-color: #ffffff;
   border-radius: 10px;
   border: 3px solid #1a1a2e;
-  position: absolute;
-  bottom: 16px;
-  left: 286px;
-  z-index: 1000;
   font-size: 12px;
   height: 80px;
   box-sizing: border-box;
@@ -1344,8 +1350,6 @@ h1 {
   }
 
   .collectible-inventory {
-    bottom: 20px;
-    right: 270px;
     max-width: 220px;
     height: 80px;
   }
@@ -1379,8 +1383,6 @@ h1 {
   }
 
   .collectible-inventory {
-    bottom: 20px;
-    right: 230px;
     max-width: 180px;
     height: 80px;
   }

--- a/tests/application/LevelGameState.test.js
+++ b/tests/application/LevelGameState.test.js
@@ -78,6 +78,39 @@ describe('LevelGameState', () => {
       expect(levelState.cursor).toBeDefined();
       expect(levelState.cursor.position).toBeDefined();
     });
+
+    test('seeds collectedKeys from options.initialCollectedKeys (carry-over across levels)', () => {
+      const carry = new Set(['h', 'j', 'k', 'l', 'w']);
+      const levelState = new LevelGameState(
+        zoneProvider,
+        levelConfig,
+        null,
+        null,
+        null,
+        { initialCollectedKeys: carry }
+      );
+
+      expect(levelState.collectedKeys).toEqual(new Set(['h', 'j', 'k', 'l', 'w']));
+    });
+
+    test('starts with an empty collectedKeys set when no initialCollectedKeys provided', () => {
+      const levelState = new LevelGameState(zoneProvider, levelConfig);
+      expect(levelState.collectedKeys.size).toBe(0);
+    });
+
+    test('seeded collectedKeys is a defensive copy (caller mutations do not leak)', () => {
+      const carry = new Set(['h']);
+      const levelState = new LevelGameState(
+        zoneProvider,
+        levelConfig,
+        null,
+        null,
+        null,
+        { initialCollectedKeys: carry }
+      );
+      carry.add('w'); // mutate the caller's set
+      expect(levelState.collectedKeys.has('w')).toBe(false);
+    });
   });
 
   describe('Zone Progression', () => {

--- a/tests/application/use-cases/MovePlayerUseCase.test.js
+++ b/tests/application/use-cases/MovePlayerUseCase.test.js
@@ -375,6 +375,125 @@ describe('MovePlayerUseCase', () => {
       });
     });
 
+    describe("word_backward (vim 'b' motion)", () => {
+      const labelAt = (x, y, text) => ({ position: new Position(x, y), text });
+      // Two words on row 5: "ab" at cols 1-2, "cd" at cols 4-5. Cursor at (5, 5) on 'd'.
+      const sameRowLabels = [
+        labelAt(1, 5, 'a'), labelAt(2, 5, 'b'),
+        labelAt(4, 5, 'c'), labelAt(5, 5, 'd'),
+      ];
+
+      it('does nothing when b key has not been collected', async () => {
+        mockGameState.collectedKeys = new Set();
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(mockGameState.cursor.position.x).toBe(5);
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('word_motion_locked');
+      });
+
+      it('does nothing when there are no text labels in the zone', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue([]);
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('no_text');
+      });
+
+      it('does nothing when the cursor is not on a text label', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue([
+          labelAt(0, 5, 'x'), labelAt(9, 5, 'y'),
+        ]);
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('not_on_text');
+      });
+
+      it('jumps cursor back to the start of the current word', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(result.success).toBe(true);
+        expect(mockGameState.cursor.position.x).toBe(4);
+        expect(mockGameState.cursor.position.y).toBe(5);
+      });
+
+      it('jumps to the start of the previous word when cursor is already at start of current', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.cursor = new Cursor(new Position(4, 5)); // start of "cd"
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(result.success).toBe(true);
+        expect(mockGameState.cursor.position.x).toBe(1);
+        expect(mockGameState.cursor.position.y).toBe(5);
+      });
+
+      it('returns no_next_word when no earlier words exist', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.cursor = new Cursor(new Position(1, 5)); // start of first word
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('no_next_word');
+      });
+
+      it('does not unlock secondary gates as a side effect of the flood-fill', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+        mockGameState.getSecondaryGates = jest.fn().mockReturnValue([
+          { position: new Position(3, 5), isWalkable: jest.fn().mockReturnValue(false) },
+        ]);
+        mockGameState.tryUnlockSecondaryGate = jest.fn().mockReturnValue(true);
+
+        await movePlayerUseCase.execute('word_backward');
+
+        expect(mockGameState.tryUnlockSecondaryGate).not.toHaveBeenCalled();
+      });
+
+      it('jumps over a full rock or wall barrier (rocks and walls are passable for b)', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+        // Entire column 3 is wall — a barrier the BFS cannot route around.
+        mockMap.isWalkable.mockImplementation((pos) => pos.x !== 3);
+        mockMap.getTileAt.mockImplementation((pos) =>
+          pos.x === 3 ? { name: 'wall', walkable: false } : { name: 'grass' }
+        );
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(result.success).toBe(true);
+        expect(mockGameState.cursor.position.x).toBe(4); // back to start of "cd"
+      });
+
+      it('refuses to jump across a full water column (water is a hard border)', async () => {
+        mockGameState.collectedKeys = new Set(['b']);
+        mockGameState.cursor = new Cursor(new Position(4, 5)); // start of "cd"
+        mockGameState.getTextLabels = jest.fn().mockReturnValue(sameRowLabels);
+        mockMap.isWalkable.mockImplementation((pos) => pos.x !== 3);
+        mockMap.getTileAt.mockImplementation((pos) =>
+          pos.x === 3 ? { name: 'water', walkable: false } : { name: 'grass' }
+        );
+
+        const result = await movePlayerUseCase.execute('word_backward');
+
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('no_next_word');
+      });
+    });
+
     it('should collect key when moving to key position', async () => {
       const key = new VimKey(new Position(6, 5), 'h', 'Move left');
       mockGameState.availableKeys = [key];

--- a/tests/domain/services/WordMotion.test.js
+++ b/tests/domain/services/WordMotion.test.js
@@ -233,3 +233,80 @@ describe('WordMotion.findNextWordEnd', () => {
     expect(target).toBeNull();
   });
 });
+
+describe('WordMotion.findPreviousWordStart', () => {
+  it('returns null for empty text labels', () => {
+    expect(WordMotion.findPreviousWordStart(new Position(0, 0), [])).toBeNull();
+    expect(WordMotion.findPreviousWordStart(new Position(0, 0), null)).toBeNull();
+  });
+
+  it('jumps from the middle of a word back to the start of the same word', () => {
+    const labels = [
+      label(0, 3, 'T'), label(1, 3, 'h'), label(2, 3, 'e'),
+      label(4, 3, 'c'), label(5, 3, 'a'), label(6, 3, 't'),
+    ];
+    const target = WordMotion.findPreviousWordStart(new Position(5, 3), labels);
+    expect(target).toEqual(new Position(4, 3));
+  });
+
+  it('jumps from the end of a word back to its start', () => {
+    const labels = [
+      label(0, 3, 'T'), label(1, 3, 'h'), label(2, 3, 'e'),
+      label(4, 3, 'c'), label(5, 3, 'a'), label(6, 3, 't'),
+    ];
+    const target = WordMotion.findPreviousWordStart(new Position(6, 3), labels);
+    expect(target).toEqual(new Position(4, 3));
+  });
+
+  it('jumps from the start of a word back to the start of the previous word', () => {
+    const labels = [
+      label(0, 3, 'T'), label(1, 3, 'h'), label(2, 3, 'e'),
+      label(4, 3, 'c'), label(5, 3, 'a'), label(6, 3, 't'),
+    ];
+    const target = WordMotion.findPreviousWordStart(new Position(4, 3), labels);
+    expect(target).toEqual(new Position(0, 3));
+  });
+
+  it('treats punctuation as a separate word', () => {
+    // "hi!" — 'hi' word at 0-1, '!' word at 2
+    const labels = [
+      label(0, 3, 'h'), label(1, 3, 'i'), label(2, 3, '!'),
+    ];
+    const target = WordMotion.findPreviousWordStart(new Position(2, 3), labels);
+    expect(target).toEqual(new Position(0, 3));
+  });
+
+  it('wraps to the previous row when no more word starts remain backwards on current row', () => {
+    const labels = [
+      label(5, 3, 'a'), label(7, 3, 'b'), label(8, 3, 'c'),
+      label(0, 5, 'd'),
+    ];
+    const target = WordMotion.findPreviousWordStart(new Position(0, 5), labels);
+    // From start of row 5's single word, b wraps to the LAST word on row 3 ("bc" at x=7).
+    expect(target).toEqual(new Position(7, 3));
+  });
+
+  it('returns null when no earlier words exist', () => {
+    const labels = [label(5, 3, 'a')];
+    expect(WordMotion.findPreviousWordStart(new Position(5, 3), labels)).toBeNull();
+  });
+
+  it('only considers labels in the same group as the cursor', () => {
+    const labels = [
+      label(0, 3, 'a', 'poem'),
+      label(5, 3, 'b', 'aside'), // different group — should be ignored
+      label(10, 3, 'c', 'poem'),
+    ];
+    // Cursor on 'c' (poem). Previous poem word is at x=0, NOT the aside at x=5.
+    const target = WordMotion.findPreviousWordStart(new Position(10, 3), labels);
+    expect(target).toEqual(new Position(0, 3));
+  });
+
+  it('returns null when a wall fully isolates the cursor from the previous word', () => {
+    const labels = [label(0, 3, 'a'), label(5, 3, 'b')];
+    // Block the entire column 3 — two disconnected regions.
+    const isWalkable = (pos) => pos.x !== 3;
+    const target = WordMotion.findPreviousWordStart(new Position(5, 3), labels, isWalkable);
+    expect(target).toBeNull();
+  });
+});

--- a/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
+++ b/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
@@ -107,6 +107,12 @@ describe('BlinkingGroveZone', () => {
       expect(hiddenVimKeys.map(k => k.value)).toContain('e');
       const eKey = hiddenVimKeys.find(k => k.value === 'e');
       expect(eKey.position).toEqual([11, 8]);
+
+      // The 'b' (word-backward motion) vim_key sits on the dirt tile just after
+      // "prevail." on the poem's last line (hidden-area coords [35, 12]).
+      expect(hiddenVimKeys.map(k => k.value)).toContain('b');
+      const bKey = hiddenVimKeys.find(k => k.value === 'b');
+      expect(bKey.position).toEqual([35, 12]);
     });
 
     test('should have correct text labels configuration', () => {

--- a/tests/infrastructure/rendering/VimKeyInfo.test.js
+++ b/tests/infrastructure/rendering/VimKeyInfo.test.js
@@ -33,6 +33,31 @@ describe('VimKeyInfo', () => {
       expect(info.category).toBe('VIM');
       expect(info.desc).toContain('unknown');
     });
+
+    // Popup descriptions explain what happens to the character (long form,
+    // matching the h/j/k/l style). The helper menu uses a separate shortLabel.
+    describe('word-jump descriptions and short labels', () => {
+      it('w has a character-focused desc and a two-word shortLabel', () => {
+        const info = VimKeyInfo.get('w');
+        expect(info.desc.toLowerCase()).toContain('character');
+        expect(info.desc.toLowerCase()).toContain('next word');
+        expect(info.shortLabel).toBe('Jump forward');
+      });
+
+      it('e has a character-focused desc and a two-word shortLabel', () => {
+        const info = VimKeyInfo.get('e');
+        expect(info.desc.toLowerCase()).toContain('character');
+        expect(info.desc.toLowerCase()).toContain('end');
+        expect(info.shortLabel).toBe('Jump end');
+      });
+
+      it('b has a character-focused desc and a two-word shortLabel', () => {
+        const info = VimKeyInfo.get('b');
+        expect(info.desc.toLowerCase()).toContain('character');
+        expect(info.desc.toLowerCase()).toContain('previous word');
+        expect(info.shortLabel).toBe('Jump back');
+      });
+    });
   });
 
   describe('_buildOverlay', () => {
@@ -274,6 +299,15 @@ describe('VimKeyInfo', () => {
     it('does nothing if container missing', () => {
       document.body.innerHTML = '';
       expect(() => VimKeyInfo.updateHelpKeys(new Set(['h']), jest.fn())).not.toThrow();
+    });
+
+    it('uses the short shortLabel (not the long popup desc) for extra-key labels', () => {
+      VimKeyInfo.updateHelpKeys(new Set(['h', 'j', 'k', 'l', 'w', 'e', 'b']), jest.fn());
+      const container = document.getElementById('helpCollectedKeys');
+      const extraLabels = Array.from(container.querySelectorAll('.help-key-row .help-key-label'))
+        .slice(4) // skip h/j/k/l rows
+        .map((el) => el.textContent);
+      expect(extraLabels).toEqual(['Jump forward', 'Jump end', 'Jump back']);
     });
   });
 });


### PR DESCRIPTION
## Summary

Several related improvements built on top of the `b` vim key. Each commit was developed strict-TDD (failing test first, smallest fix, then refactor).

### `b` vim key (word-backward motion)
- Adds the `b` vim key at `[35, 12]` — the dirt tile just after "prevail." on the poem's last line. Collecting it unlocks vim's word-backward motion: cursor jumps back to the start of the current word, or to the start of the previous word if already at start.
- Generalises `WordMotion` candidate collection with a direction parameter so backward search reuses the existing group-filter + flood-fill walkability + word-start extractor. Three exported queries now: `findNextWordStart` (`w`), `findNextWordEnd` (`e`), `findPreviousWordStart` (`b`).
- `MovePlayerUseCase` routes `word_backward` through the same shared `_executeWordMotion(requiredKey, findTarget)` helper used by `w` and `e` — same five guards apply (locked without key, no text, cursor-not-on-text, no candidate, target unreachable). Walls and rocks remain jumpable; water remains a hard border.
- `KeyboardInputHandler`: `b` mapped to `word_backward`.

### HUD layout fix
- The collected-keys panel and the collectible-key inventory were both absolutely positioned at fixed left offsets (16px and 286px). Once the player collected ~7 keys the left panel grew past 270px and clipped the inventory behind it.
- Wrapped both in a `.bottom-ui-bar` flex container absolutely positioned at the bottom-left with `gap: 16px`. Panels now grow naturally and slide each other rightward instead of overlapping.

### Helper menu & popup copy
- Split the single `desc` field into two audiences:
  - `desc` keeps the long character-focused explanation shown in the "NEW KEY UNLOCKED!" popup (matches `l`'s style: "Moves your character one step to the RIGHT.").
  - New `shortLabel` field holds the two-word label shown under each chip in the "Your Keys" helper menu.
- `w/e/b` now show "Jumps your character forward/end/back to..." in the popup and "Jump forward / Jump end / Jump back" in the helper menu, fitting all three on one row beneath the divider.
- `updateHelpKeys` prefers `info.shortLabel` and falls back to the legacy first-sentence-of-desc for any key without a short label.

### Cross-level key carry-over
- `LevelGameState` accepts an optional `options.initialCollectedKeys` Set; when provided it seeds `collectedKeys` with a defensive copy.
- `VimForKidsGame.transitionToLevel` captures the outgoing `gameState.collectedKeys` before cleanup and pipes it into the new `LevelGameState`. Player keeps motion abilities (and any other capability gated on `collectedKeys`) across level boundaries.
- Per-zone gate logic is unchanged — a gate inside a zone still gates on per-zone collection, so each zone's puzzle has to be solved locally.

## Test plan

- [x] **WordMotion** — `findPreviousWordStart` (8 new tests): middle-of-word → start, end → start, start → previous-start, punctuation, row-wrap, group filter, wall isolation, walkability predicate
- [x] **MovePlayerUseCase `word_backward` flow** — 9 new tests: locked without key, no text, not-on-text, jump-to-start, start-to-prev-start, no-prev-word, no-side-effect gate-unlock, wall jumpable, water not jumpable
- [x] **Zone test** — `b` vim_key present at `[35, 12]`
- [x] **VimKeyInfo** — `desc` mentions "character" + key-specific noun; `shortLabel` is the exact two-word string; helper menu renders the short version, not the long one
- [x] **LevelGameState** — `initialCollectedKeys` seeding, empty default, defensive copy from caller mutations
- [x] All 1766 tests pass; build clean
- [x] Coverage on new code: WordMotion 99.11%, MovePlayerUseCase 91.12%, LevelGameState 91.11%

## Manual verification

- [x] Reload — collect h, j, k, l, w, e, b in zone 1; helper menu shows all three word-jumps on one row, popups show full character-action explanation
- [x] Reload — fill the collected-keys panel; inventory now slides right instead of being covered
- [x] Reload — finish zone 1, transition to zone 2; pressing `w` / `e` / `b` still works without re-collecting the keys