### PR TITLE
fix: auto-focus the canvas after a cutscene closes

### DIFF
--- a/src/infrastructure/ui/CutsceneRenderer.js
+++ b/src/infrastructure/ui/CutsceneRenderer.js
@@ -207,6 +207,12 @@ export class CutsceneRenderer {
     return new Promise((resolve) => {
       const cutsceneType = cutsceneStory.type || 'game';
 
+      // Remember which element had focus before the overlay stole it so
+      // we can hand focus back to the game board on close — keeps keyboard
+      // input flowing without the player having to click the canvas first.
+      this._focusBeforeCutscene =
+        typeof document !== 'undefined' ? document.activeElement : null;
+
       this._createCutsceneOverlay(cutsceneType);
       this._isVisible = true;
 
@@ -230,6 +236,24 @@ export class CutsceneRenderer {
     this._cutsceneOverlay = null;
     this._isVisible = false;
     this._clearTimeouts();
+    // Restore keyboard focus to the canvas (or whatever element held it
+    // before the cutscene) so the player can move immediately on close
+    // without having to click anything first.
+    this._restoreFocus();
+  }
+
+  _restoreFocus() {
+    if (typeof document === 'undefined') return;
+    const previous = this._focusBeforeCutscene;
+    this._focusBeforeCutscene = null;
+    // Prefer the focusable game canvas — that's where the keyboard
+    // handler is attached — but fall back to whoever held focus when
+    // the cutscene started.
+    const canvas = document.getElementById('gameBoardCanvas');
+    const target = canvas || (previous && typeof previous.focus === 'function' ? previous : null);
+    if (target && typeof target.focus === 'function') {
+      target.focus();
+    }
   }
 
   /**

--- a/tests/infrastructure/ui/CutsceneRenderer.test.js
+++ b/tests/infrastructure/ui/CutsceneRenderer.test.js
@@ -394,6 +394,29 @@ describe('Cutscene Type Detection', () => {
     await secondDone;
   });
 
+  it('restores keyboard focus to the game canvas on close', async () => {
+    // Stand in for the focusable canvas the keyboard handler listens on.
+    const canvas = document.createElement('canvas');
+    canvas.id = 'gameBoardCanvas';
+    canvas.setAttribute('tabindex', '0');
+    document.body.appendChild(canvas);
+    const focusSpy = jest.spyOn(canvas, 'focus');
+
+    const story = {
+      gameId: 'test-game',
+      type: 'level',
+      levelId: 'l1',
+      script: ['One line'],
+    };
+    const done = renderer.showCutscene(story);
+    const overlay = document.querySelector('div[style*="z-index: 10000"]');
+    overlay.click();
+    await done;
+
+    expect(focusSpy).toHaveBeenCalled();
+    canvas.remove();
+  });
+
   it('should use zone background for zone cutscenes', async () => {
     const zoneStory = {
       gameId: 'test-game',


### PR DESCRIPTION
## Summary

Closes task #56 (auto-focus after cutscene). The remaining pending tasks (#47 Level 2 redesign, #55 hidden-area anchor drift, #60 top-down PNG gate) are larger and will land in follow-up PRs.

- `CutsceneRenderer._presentCutscene` captures `document.activeElement` when the overlay mounts.
- `hideCutscene` now refocuses `#gameBoardCanvas` (the canvas the keyboard handler listens on), falling back to whatever held focus before the cutscene started.
- Keyboard input flows the moment the cutscene dismisses — no more "click the canvas first" friction.

## Test plan
- [ ] Reload the game, dismiss the origin cutscene, immediately try h/j/k/l — the cursor moves with no mouse click required
- [ ] Transition to level 2; after the level cutscene dismisses, keyboard control is live for the zone cutscene
- [ ] `npm run validate` — 1884 tests pass, branches 80.13%