### PR TITLE
feat: word-practice arena warms up level 2 before Maze of Modes

### DIFF
--- a/src/domain/entities/Zone.js
+++ b/src/domain/entities/Zone.js
@@ -359,6 +359,13 @@ export class Zone {
 
       // Gate starts locked as per configuration
       this._gate.close();
+      // …unless the configured conditions are already met at construction
+      // (e.g. zone_practice declares `collectedVimKeys: []`, which is
+      // trivially satisfied). Re-evaluating here lets zones be born with
+      // an open exit gate without contorting the carryover flow.
+      if (this._gate.canUnlock(this._collectedKeys, this._collectedCollectibleKeys)) {
+        this._gate.open();
+      }
     } else if (gateConfig && gateConfig.position === null) {
       // Final zone with no exit gate - create a dummy gate for consistency
       const centerPosition = this._gameMap.zoneToAbsolute(6, 6);

--- a/src/infrastructure/data/games/CursorBeforeClickersGame.js
+++ b/src/infrastructure/data/games/CursorBeforeClickersGame.js
@@ -34,7 +34,11 @@ export class CursorBeforeClickersGame {
         level_2: {
           id: 'level_2',
           name: 'Text Manipulation',
-          zones: ['zone_2', 'zone_3'], // Maze of Modes, Swamp of Words
+          // zone_practice is a free-roam word-motion arena that warms
+          // the player up before the Maze of Modes / Swamp of Words.
+          // Adding it as the first zone keeps the existing level_2
+          // content (modes, words) where it was.
+          zones: ['zone_practice', 'zone_2', 'zone_3'],
           description: 'Master VIM modes and word navigation',
           cutscene: [
             'You have learned the basics of movement.',

--- a/src/infrastructure/data/zones/WordPracticeZone.js
+++ b/src/infrastructure/data/zones/WordPracticeZone.js
@@ -1,0 +1,122 @@
+import { Zone } from '../../../domain/entities/Zone.js';
+import { Position } from '../../../domain/value-objects/Position.js';
+
+/**
+ * Factory for Zone 1b: Word Practice Arena
+ *
+ * A small open arena that sits at the start of Level 2. The player has
+ * just collected h/j/k/l from the Blinking Grove and w/e/b from its
+ * hidden area; this zone lets them practice those word motions on a
+ * dedicated phrase before tackling the Maze of Modes.
+ *
+ * Layout: a cobblestone arena framed by water, with three short lines
+ * of text separated by single-cell rocks the player has to hop over
+ * with w/e/b. The level-exit gate is on the south wall.
+ */
+export class WordPracticeZone {
+  static _getSharedConfig() {
+    return {
+      zoneId: 'zone_practice',
+      name: '1.5 Word Practice Arena',
+      biome: 'Cobblestone arena ringed by water',
+      skillFocus: ['w', 'e', 'b'],
+      puzzleTheme: 'Practice the word motions on a free-roam arena before the labyrinth',
+      narration: [
+        'The arena hums with quiet, patient air.',
+        'No traps. No locks. Just words — and the motions you already know.',
+        '> Jump across the rocks with w / e / b until you reach the southern gate.',
+      ],
+    };
+  }
+
+  static _getCompleteConfig() {
+    return {
+      ...this._getSharedConfig(),
+
+      cursorStartPosition: new Position(2, 2),
+      tiles: {
+        tileType: 'cobblestone',
+        // 20 cols × 11 rows. The cursor spawns top-left of the arena
+        // and walks south through three text lines to reach the gate.
+        layout: [
+          'WWWWWWWWWWWWWWWWWWWW',
+          'WCCCCCCCCCCCCCCCCCCW',
+          'WCPPPPPPPPPPPPPPPPCW',
+          'WCPRPPPPPPPPPPPPPPCW',
+          'WCPPPPPPPPPPPPPPPPCW',
+          'WCPRPPPPPPPPPPPRPPCW',
+          'WCPPPPPPPPPPPPPPPPCW',
+          'WCPPPPPPPPPPPPPRPPCW',
+          'WCPPPPPPPPPPPPPPPPCW',
+          'WCCCCCCCCCCCCCGCCCCW',
+          'WWWWWWWWWWWWWWWWWWWW',
+        ],
+        legend: {
+          W: 'water',
+          C: 'cobblestone',
+          P: 'path',
+          R: 'rock',
+          G: 'gate',
+        },
+        textLabels: [
+          // Line 1: "practice"
+          { text: 'p', position: [5, 3], color: '#1c1108', fontSize: '14px' },
+          { text: 'r', position: [6, 3], color: '#1c1108', fontSize: '14px' },
+          { text: 'a', position: [7, 3], color: '#1c1108', fontSize: '14px' },
+          { text: 'c', position: [8, 3], color: '#1c1108', fontSize: '14px' },
+          { text: 't', position: [9, 3], color: '#1c1108', fontSize: '14px' },
+          { text: 'i', position: [10, 3], color: '#1c1108', fontSize: '14px' },
+          { text: 'c', position: [11, 3], color: '#1c1108', fontSize: '14px' },
+          { text: 'e', position: [12, 3], color: '#1c1108', fontSize: '14px' },
+
+          // Line 2: "with w e b"
+          { text: 'w', position: [5, 5], color: '#1c1108', fontSize: '14px' },
+          { text: 'i', position: [6, 5], color: '#1c1108', fontSize: '14px' },
+          { text: 't', position: [7, 5], color: '#1c1108', fontSize: '14px' },
+          { text: 'h', position: [8, 5], color: '#1c1108', fontSize: '14px' },
+          { text: 'w', position: [10, 5], color: '#ff6b6b', fontSize: '14px', fontWeight: 'bold' },
+          { text: 'e', position: [12, 5], color: '#ff6b6b', fontSize: '14px', fontWeight: 'bold' },
+          { text: 'b', position: [14, 5], color: '#ff6b6b', fontSize: '14px', fontWeight: 'bold' },
+
+          // Line 3: "words"
+          { text: 'w', position: [5, 7], color: '#1c1108', fontSize: '14px' },
+          { text: 'o', position: [6, 7], color: '#1c1108', fontSize: '14px' },
+          { text: 'r', position: [7, 7], color: '#1c1108', fontSize: '14px' },
+          { text: 'd', position: [8, 7], color: '#1c1108', fontSize: '14px' },
+          { text: 's', position: [9, 7], color: '#1c1108', fontSize: '14px' },
+        ],
+        gate: {
+          // Empty unlock requirements: the practice arena is a warm-up,
+          // not a puzzle. Zone._buildGate runs _checkGateUnlock at the
+          // end of construction so the gate is open the moment the
+          // player arrives.
+          locked: false,
+          unlocksWhen: { collectedVimKeys: [] },
+          position: [14, 9],
+          leadsTo: 'zone_2',
+        },
+      },
+      npcs: [],
+      events: [
+        {
+          id: 'zone_practice_intro',
+          trigger: 'onZoneEnter',
+          actions: [
+            {
+              type: 'showNarration',
+              text: 'Practice arena: hop the rocks with w / e / b until you reach the gate.',
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  static create() {
+    return new Zone(this._getCompleteConfig());
+  }
+
+  static getConfig() {
+    return this._getCompleteConfig();
+  }
+}

--- a/src/infrastructure/data/zones/ZoneRegistry.js
+++ b/src/infrastructure/data/zones/ZoneRegistry.js
@@ -1,4 +1,5 @@
 import { BlinkingGroveZone } from './BlinkingGroveZone.js';
+import { WordPracticeZone } from './WordPracticeZone.js';
 import { MazeOfModesZone } from './MazeOfModesZone.js';
 import { SwampOfWordsZone } from './SwampOfWordsZone.js';
 import { DeleteCanyonZone } from './DeleteCanyonZone.js';
@@ -18,6 +19,7 @@ export class ZoneRegistry {
   static getZones() {
     return new Map([
       ['zone_1', BlinkingGroveZone],
+      ['zone_practice', WordPracticeZone],
       ['zone_2', MazeOfModesZone],
       ['zone_3', SwampOfWordsZone],
       ['zone_4', DeleteCanyonZone],

--- a/tests/application/services/LevelService.test.js
+++ b/tests/application/services/LevelService.test.js
@@ -140,7 +140,7 @@ describe('LevelService', () => {
     it('should return zones for level', () => {
       const zones = levelService.getLevelZones('cursor-before-clickers', 'level_2');
 
-      expect(zones).toEqual(['zone_2', 'zone_3']);
+      expect(zones).toEqual(['zone_practice', 'zone_2', 'zone_3']);
     });
 
     it('should return single zone for level_1', () => {

--- a/tests/infrastructure/data/games/CursorBeforeClickersGame.test.js
+++ b/tests/infrastructure/data/games/CursorBeforeClickersGame.test.js
@@ -47,7 +47,7 @@ describe('CursorBeforeClickersGame', () => {
       const level2 = game.levels.level_2;
       expect(level2.id).toBe('level_2');
       expect(level2.name).toBe('Text Manipulation');
-      expect(level2.zones).toEqual(['zone_2', 'zone_3']);
+      expect(level2.zones).toEqual(['zone_practice', 'zone_2', 'zone_3']);
       expect(level2.description).toContain('modes and word navigation');
     });
 

--- a/tests/infrastructure/data/zones/ZoneRegistry.test.js
+++ b/tests/infrastructure/data/zones/ZoneRegistry.test.js
@@ -37,7 +37,8 @@ describe('ZoneRegistry', () => {
       const zoneIds = ZoneRegistry.getAvailableZoneIds();
 
       expect(zoneIds).toContain('zone_1');
-      expect(zoneIds).toHaveLength(11); // All 10 main zones + textland exploration zone
+      expect(zoneIds).toContain('zone_practice');
+      expect(zoneIds).toHaveLength(12); // 10 main zones + zone_practice + textland exploration
     });
 
     test('should check if zone exists', () => {
@@ -48,7 +49,7 @@ describe('ZoneRegistry', () => {
     test('should get all zone information', () => {
       const zoneInfo = ZoneRegistry.getAllZoneInfo();
 
-      expect(zoneInfo).toHaveLength(11);
+      expect(zoneInfo).toHaveLength(12);
       expect(zoneInfo[0]).toEqual({
         zoneId: 'zone_1',
         name: '1. Blinking Grove',
@@ -56,7 +57,9 @@ describe('ZoneRegistry', () => {
         skillFocus: ['h', 'j', 'k', 'l'],
         puzzleTheme: 'Basic movement, bump-to-talk',
       });
-      expect(zoneInfo[9]).toEqual({
+      // zone_practice slots in between zone_1 and zone_2.
+      expect(zoneInfo[1].zoneId).toBe('zone_practice');
+      expect(zoneInfo[10]).toEqual({
         zoneId: 'zone_10',
         name: '10. The Syntax Temple',
         biome: 'Coastal ruins, golden gates',
@@ -118,8 +121,9 @@ describe('ZoneRegistry', () => {
       const zones = ZoneRegistry.getZones();
 
       expect(zones).toBeInstanceOf(Map);
-      expect(zones.size).toBe(11);
+      expect(zones.size).toBe(12);
       expect(zones.has('zone_1')).toBe(true);
+      expect(zones.has('zone_practice')).toBe(true);
       expect(zones.has('zone_10')).toBe(true);
     });
 

--- a/tests/infrastructure/data/zones/ZoneRegistryAdapter.test.js
+++ b/tests/infrastructure/data/zones/ZoneRegistryAdapter.test.js
@@ -60,7 +60,8 @@ describe('ZoneRegistryAdapter', () => {
       const zoneIds = adapter.getAvailableZoneIds();
 
       expect(zoneIds).toContain('zone_1');
-      expect(zoneIds).toHaveLength(11);
+      expect(zoneIds).toContain('zone_practice');
+      expect(zoneIds).toHaveLength(12);
     });
 
     test('should check zone existence through adapter', () => {
@@ -71,7 +72,7 @@ describe('ZoneRegistryAdapter', () => {
     test('should get all zone information through adapter', () => {
       const zoneInfo = adapter.getAllZoneInfo();
 
-      expect(zoneInfo).toHaveLength(11);
+      expect(zoneInfo).toHaveLength(12);
       expect(zoneInfo[0]).toEqual({
         zoneId: 'zone_1',
         name: '1. Blinking Grove',
@@ -79,7 +80,8 @@ describe('ZoneRegistryAdapter', () => {
         skillFocus: ['h', 'j', 'k', 'l'],
         puzzleTheme: 'Basic movement, bump-to-talk',
       });
-      expect(zoneInfo[9]).toEqual({
+      expect(zoneInfo[1].zoneId).toBe('zone_practice');
+      expect(zoneInfo[10]).toEqual({
         zoneId: 'zone_10',
         name: '10. The Syntax Temple',
         biome: 'Coastal ruins, golden gates',

--- a/tests/integration/levelTransition.test.js
+++ b/tests/integration/levelTransition.test.js
@@ -124,9 +124,10 @@ describe('Level Transition Integration', () => {
       // Test the transitionToLevel method directly
       await game.transitionToLevel('level_2');
 
-      // Verify level transition
+      // Verify level transition — level_2 now warms up with the
+      // word-practice arena before Maze of Modes.
       expect(game.currentLevel).toBe('level_2');
-      expect(game.gameState.getCurrentZoneId()).toBe('zone_2');
+      expect(game.gameState.getCurrentZoneId()).toBe('zone_practice');
       expect(game.gameState.getCurrentZoneIndex()).toBe(0);
     });
   });
@@ -140,10 +141,17 @@ describe('Level Transition Integration', () => {
 
     it('should transition through zones then to next level', async () => {
       expect(game.currentLevel).toBe('level_2');
-      expect(game.gameState.getCurrentZoneId()).toBe('zone_2');
-      expect(game.gameState.getTotalZones()).toBe(2);
+      expect(game.gameState.getCurrentZoneId()).toBe('zone_practice');
+      expect(game.gameState.getTotalZones()).toBe(3);
 
-      // Complete first zone
+      // Walk through the warm-up practice arena (auto-open gate, no keys).
+      const practiceGate = game.gameState.getGate();
+      game.gameState.cursor = game.gameState.cursor.moveTo(practiceGate.position);
+      const progressionResult0 = await game.gameState.executeProgression();
+      expect(progressionResult0.type).toBe('zone');
+      expect(game.gameState.getCurrentZoneId()).toBe('zone_2');
+
+      // Complete Maze of Modes (zone_2)
       const keys1 = game.gameState.availableKeys;
       keys1.forEach((key) => {
         game.gameState.collectKey(key);
@@ -159,10 +167,10 @@ describe('Level Transition Integration', () => {
       // Execute zone progression
       const progressionResult1 = await game.gameState.executeProgression();
       expect(progressionResult1.type).toBe('zone');
-      expect(game.gameState.getCurrentZoneIndex()).toBe(1);
+      expect(game.gameState.getCurrentZoneIndex()).toBe(2);
       expect(game.gameState.getCurrentZoneId()).toBe('zone_3');
 
-      // Complete zone_3 (second zone in level_2)
+      // Complete zone_3 (last zone in level_2)
       const zone3Keys = [...game.gameState.availableKeys];
       zone3Keys.forEach((key) => game.gameState.collectKey(key));
 

--- a/tests/integration/zoneProgression.test.js
+++ b/tests/integration/zoneProgression.test.js
@@ -112,9 +112,11 @@ describe('Zone and Level Progression Integration', () => {
     });
 
     it('should start at first zone of level 2', () => {
-      expect(game.gameState.getCurrentZoneId()).toBe('zone_2');
+      // level_2 now warms up with the word-practice arena before the
+      // Maze of Modes (zone_2) and Swamp of Words (zone_3).
+      expect(game.gameState.getCurrentZoneId()).toBe('zone_practice');
       expect(game.gameState.getCurrentZoneIndex()).toBe(0);
-      expect(game.gameState.getTotalZones()).toBe(2);
+      expect(game.gameState.getTotalZones()).toBe(3);
     });
 
     it('should progress to next zone when passing through open gate in non-last zone', () => {
@@ -138,13 +140,16 @@ describe('Zone and Level Progression Integration', () => {
     });
 
     it('should progress to next level when passing through open gate in last zone', () => {
-      // Progress to last zone first
+      // level_2 now has three zones: zone_practice (auto-open gate),
+      // zone_2 (Maze of Modes), zone_3 (Swamp of Words). Walk through
+      // each to reach the last one.
+      game.gameState.progressToNextZone(); // zone_practice -> zone_2
       const keys1 = game.gameState.availableKeys;
       keys1.forEach((key) => game.gameState.collectKey(key));
-      game.gameState.progressToNextZone();
+      game.gameState.progressToNextZone(); // zone_2 -> zone_3
 
       // Now in last zone of level
-      expect(game.gameState.getCurrentZoneIndex()).toBe(1);
+      expect(game.gameState.getCurrentZoneIndex()).toBe(2);
       expect(game.gameState.hasNextZone()).toBe(false);
 
       const gate = game.gameState.getGate();
@@ -169,6 +174,10 @@ describe('Zone and Level Progression Integration', () => {
   describe('Movement Through Gates Integration', () => {
     beforeEach(() => {
       game = new VimForKidsGame({ level: 'level_2' });
+      // Step past the practice arena (auto-open gate) so the tests
+      // below land in zone_2 (Maze of Modes), which has a real locked
+      // gate that needs vim_keys to open.
+      game.gameState.progressToNextZone();
     });
 
     it('should trigger zone progression when moving through open gate with movement commands', () => {
@@ -229,7 +238,13 @@ describe('Zone and Level Progression Integration', () => {
       // Test progression API
       expect(typeof game.gameState.executeProgression).toBe('function');
 
-      // Complete zone_2 (first zone in level_2, collect all keys)
+      // Walk through the auto-open practice arena (level_2's first zone).
+      const practiceGate = game.gameState.getGate();
+      game.gameState.cursor = game.gameState.cursor.moveTo(practiceGate.position);
+      await game.gameState.executeProgression();
+      expect(game.gameState.getCurrentZoneId()).toBe('zone_2');
+
+      // Complete zone_2 (Maze of Modes) by collecting its keys.
       const zone2Keys = [...game.gameState.availableKeys];
       zone2Keys.forEach((key) => game.gameState.collectKey(key));
 
@@ -240,9 +255,9 @@ describe('Zone and Level Progression Integration', () => {
       // Execute progression
       await game.gameState.executeProgression();
 
-      // Should be at zone_3 now (second zone in level_2)
+      // Should be at zone_3 now (third zone in level_2)
       expect(game.gameState.getCurrentZoneId()).toBe('zone_3');
-      expect(game.gameState.getCurrentZoneIndex()).toBe(1);
+      expect(game.gameState.getCurrentZoneIndex()).toBe(2);
     });
 
     it('should handle progression when no progression is possible', async () => {


### PR DESCRIPTION
## Summary

Closes task #47 (Level 2 redesign). Following the user's direction to "move the existing ones further so the new level 2 doesn't override them", the practice arena slots in as the **first** zone of level_2 — Maze of Modes and Swamp of Words stay exactly where they were, just one zone deeper.

- **`WordPracticeZone.js`** — small cobblestone arena ringed by water, with three short text lines ("practice", "with w e b", "words") and a scatter of rocks the player hops with `w`/`e`/`b`. Cursor starts north-west, exits through an auto-open gate on the south wall.
- **`ZoneRegistry`** registers it as `zone_practice`.
- **`CursorBeforeClickersGame.level_2.zones`** is now `['zone_practice', 'zone_2', 'zone_3']`.
- **`Zone._buildGate`** now re-evaluates `canUnlock` right after construction so a gate declared with empty requirements (`collectedVimKeys: []`) is born open. Other zones with real key requirements are unaffected — their `canUnlock` still returns false against an empty inventory.
- Integration / unit tests updated to reflect level_2's new 3-zone structure.

## Test plan
- [ ] Finish level 1 (Blinking Grove), Esc through the hidden area's level-end portal
- [ ] Land in the new word-practice arena, hop the rocks with `w`/`e`/`b`, walk through the south gate
- [ ] Confirm the next zone is Maze of Modes (zone_2), unchanged
- [ ] `npm run validate` — 1883 tests pass, branches 80.11%