### PR TITLE
fix: GitHub Pages tileset 404 via __BASE_URL__

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
     "globals": {
       "__DEV__": "readonly",
       "__BUILD_DATE__": "readonly",
-      "__GIT_HASH__": "readonly"
+      "__GIT_HASH__": "readonly",
+      "__BASE_URL__": "readonly"
     },
     "rules": {
       "no-console": [

--- a/src/infrastructure/ui/CanvasGameRenderer.js
+++ b/src/infrastructure/ui/CanvasGameRenderer.js
@@ -22,7 +22,12 @@ import {
   pickGrassEdges,
 } from '../rendering/TileOverlayRules.js';
 
-const RPG_TILESET_URL = '/assets/sprites/tileset-rpg.png';
+// Resolve the tileset URL through Vite's __BASE_URL__ define so it works
+// both on the dev server (`/`) and under the GitHub Pages subpath
+// (`/VIM-for-kids/`). The typeof guard keeps Jest happy when the global
+// isn't injected.
+const _resolvedBase = typeof __BASE_URL__ !== 'undefined' ? __BASE_URL__ : '/';
+const RPG_TILESET_URL = `${_resolvedBase}assets/sprites/tileset-rpg.png`;
 
 /**
  * Canvas-based game renderer implementing the GameRenderer port.

--- a/vite.config.js
+++ b/vite.config.js
@@ -99,5 +99,8 @@ export default defineConfig({
     __DEV__: JSON.stringify(process.env.NODE_ENV === 'development'),
     __BUILD_DATE__: JSON.stringify(getBuildTimestamp()),
     __GIT_HASH__: JSON.stringify(getGitHash()),
+    __BASE_URL__: JSON.stringify(
+      process.env.NODE_ENV === 'production' ? '/VIM-for-kids/' : '/'
+    ),
   },
 });


### PR DESCRIPTION
## Summary
- The RPG tileset was hardcoded as `/assets/sprites/tileset-rpg.png`. On `helmedeiros.github.io/VIM-for-kids/` the leading slash resolved to the host root, the PNG 404'd, and the renderer fell back to procedural tiles.
- Added a Vite `define` for `__BASE_URL__` (`/VIM-for-kids/` in prod, `/` in dev) and prepended it to the tileset path. `typeof` guard keeps Jest happy where the global isn't injected; ESLint globals updated.

## Test plan
- [x] `npx jest` — 1894/1894 pass
- [x] `NODE_ENV=production vite build` — verified the built bundle contains `/VIM-for-kids/assets/sprites/tileset-rpg.png`
- [ ] After deploy, reload `https://helmedeiros.github.io/VIM-for-kids/` and confirm the RPG tileset loads (no 404, no "RPG tileset unavailable" console warning)