### PR TITLE
fix: pre-reveal level 1 secret grove to avoid mid-game resolution jump

### DIFF
--- a/src/domain/entities/Zone.js
+++ b/src/domain/entities/Zone.js
@@ -148,6 +148,18 @@ export class Zone {
     this._hiddenAreas = config.tiles.hiddenAreas || [];
     this._revealedHiddenAreas = new Set();
     this._currentHiddenArea = null; // Track which hidden area player is currently in
+
+    // Pre-reveal any hidden area authored with `revealWhen: 'always'`.
+    // Lets a zone keep the structural separation between "main map" and
+    // "secret area" data while rendering both from the start — the map
+    // expands at construction time, before any camera math runs, so
+    // there's no jarring resolution change when the player walks in.
+    this._hiddenAreas
+      .filter((area) => area.revealWhen === 'always')
+      .forEach((area) => {
+        this._revealHiddenArea(area);
+        this._revealedHiddenAreas.add(area.id);
+      });
   }
 
   _buildTiles(tilesConfig) {

--- a/src/infrastructure/data/zones/BlinkingGroveZone.js
+++ b/src/infrastructure/data/zones/BlinkingGroveZone.js
@@ -170,7 +170,13 @@ export class BlinkingGroveZone {
         hiddenAreas: [
           {
             id: 'vim_secret_area',
-            revealWhen: 'escProgression',
+            // Always pre-revealed at zone construction. Keeps the
+            // structural separation between "main map" and "secret
+            // grove" but renders the entire layout from the start so
+            // the camera doesn't have to rescale when the player
+            // walks through the gate (used to cause a noticeable
+            // resolution jump mid-game).
+            revealWhen: 'always',
             layout: [
               'CWWWWWWWWWWWWWWWPPPPPPPPRPPRPPPPPPPPWWWWWWWWWWWWWWWW',
               'PWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWCWWWWWWWWWWWWWWWW',

--- a/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
+++ b/tests/infrastructure/data/zones/BlinkingGroveZone.test.js
@@ -248,8 +248,10 @@ describe('BlinkingGroveZone', () => {
     });
 
     test('should create functional zone with all components', () => {
-      expect(zone.vimKeys).toHaveLength(4);
-      expect(zone.textLabels).toHaveLength(37); // Updated for new text layout with additional characters
+      // 4 main-area movement keys (h/j/k/l) + 3 word-motion keys
+      // (w/e/b) inside the secret grove, which is pre-revealed at
+      // construction so the camera doesn't rescale when entered.
+      expect(zone.vimKeys).toHaveLength(7);
       expect(zone.gate).toBeDefined();
       expect(zone.npcs).toHaveLength(3);
       expect(zone.events).toHaveLength(3);
@@ -279,7 +281,9 @@ describe('BlinkingGroveZone', () => {
         zone.collectKey(key);
       });
 
-      expect(zone.getCollectedKeysCount()).toBe(4);
+      // Zone now exposes 7 keys (h/j/k/l + w/e/b from the pre-revealed
+      // secret grove). The gate still unlocks on the h/j/k/l set.
+      expect(zone.getCollectedKeysCount()).toBe(7);
       expect(zone.gate.isOpen).toBe(true);
       expect(zone.isComplete()).toBe(true);
 
@@ -310,9 +314,14 @@ describe('BlinkingGroveZone', () => {
       const zone = BlinkingGroveZone.create();
 
       const configKeys = config.skillFocus.sort();
-      const zoneKeys = zone.vimKeys.map((k) => k.key).sort();
-
-      expect(configKeys).toEqual(zoneKeys);
+      // skillFocus tracks the *main-area* introductory keys; the
+      // pre-revealed secret grove adds bonus word-motion keys
+      // (w/e/b) on top, so we check skillFocus is a subset of the
+      // zone's full key set rather than an exact match.
+      const zoneKeys = zone.vimKeys.map((k) => k.key);
+      for (const key of configKeys) {
+        expect(zoneKeys).toContain(key);
+      }
     });
 
     test('should have consistent gate unlock conditions', () => {

--- a/tests/integration/blinkingGroveGame.test.js
+++ b/tests/integration/blinkingGroveGame.test.js
@@ -71,7 +71,7 @@ describe('Blinking Grove Game Integration', () => {
     });
 
     it('should have 4 movement keys available', () => {
-      expect(game.gameState.availableKeys).toHaveLength(4);
+      expect(game.gameState.availableKeys).toHaveLength(7);
 
       const keyLetters = game.gameState.availableKeys.map((key) => key.key);
       expect(keyLetters).toContain('h');
@@ -82,7 +82,10 @@ describe('Blinking Grove Game Integration', () => {
 
     it('should display text labels on the ground', () => {
       const textLabels = game.gameState.getTextLabels();
-      expect(textLabels).toHaveLength(37); // "Remember: words are not WORDS" + entry punctuation + "Hello world!"
+      // Main-area labels (37) + the secret grove's poem (now pre-revealed)
+      // bring the total to 242. The grove is visible from the start so the
+      // map dimensions don't change when the player crosses the gate.
+      expect(textLabels).toHaveLength(242);
 
       // Check that the individual characters for "Hello world!" are present
       const textContents = textLabels.map((label) => label.text);
@@ -167,33 +170,35 @@ describe('Blinking Grove Game Integration', () => {
       game.gameState.collectKey(game.gameState.availableKeys.find(k => k.key === 'h'));
 
       expect(game.gameState.collectedKeys.has('h')).toBe(true);
-      expect(game.gameState.availableKeys).toHaveLength(3);
+      expect(game.gameState.availableKeys).toHaveLength(6);
     });
 
     it('should track progress of key collection', () => {
       const keys = [...game.gameState.availableKeys];
 
-      // Collect keys one by one
+      // Collect keys one by one — there are now 7 (4 main + 3 secret).
       keys.forEach((key, index) => {
         game.gameState.collectKey(key);
         expect(game.gameState.collectedKeys.size).toBe(index + 1);
       });
 
-      expect(game.gameState.collectedKeys.size).toBe(4);
+      expect(game.gameState.collectedKeys.size).toBe(7);
       expect(game.gameState.isCurrentZoneComplete()).toBe(true);
     });
   });
 
   describe('Gate Mechanics', () => {
-    it('should keep gate closed until all keys are collected', () => {
+    it('should keep gate closed until the h/j/k/l movement set is collected', () => {
       const gate = game.gameState.getGate();
-      const keys = [...game.gameState.availableKeys];
-
-      // Collect partial keys
-      for (let i = 0; i < keys.length - 1; i++) {
-        game.gameState.collectKey(keys[i]);
-        expect(gate.isOpen).toBe(false);
-      }
+      // The gate unlocks specifically on h/j/k/l (skillFocus), so
+      // collect everything *except* the main-area movement keys and
+      // the gate must stay shut.
+      const movementSet = new Set(['h', 'j', 'k', 'l']);
+      const nonMovement = game.gameState.availableKeys.filter(
+        (k) => !movementSet.has(k.key)
+      );
+      nonMovement.forEach((k) => game.gameState.collectKey(k));
+      expect(gate.isOpen).toBe(false);
     });
 
     it('should open gate after collecting all 4 movement keys', () => {
@@ -610,18 +615,13 @@ describe('Blinking Grove Game Integration', () => {
           }
         }
 
-                // Interact with gate to reveal hidden area (simulate ESC key press exactly like real game)
+        // The secret grove is now pre-revealed at zone construction
+        // (`revealWhen: 'always'`) so the camera doesn't rescale when
+        // the player walks in. Calling reveal again is a no-op — the
+        // contents are already on the map. Just teleport to the
+        // documented hidden-area start so the rest of this test keeps
+        // exercising the collectible flow.
         if (mainGate.leadsTo === 'vim_secret_area') {
-          // Step 1: Reveal the hidden area (exactly like real game)
-          const revealed = game.gameState.zone.revealHiddenArea('escProgression');
-          expect(revealed).toBe(true);
-
-          // Step 2: Enter the hidden area (exactly like real game)
-          const hiddenArea = game.gameState.zone.enterHiddenArea('vim_secret_area');
-          expect(hiddenArea).toBeTruthy();
-          expect(hiddenArea.id).toBe('vim_secret_area');
-
-          // Step 3: Move player to hidden area start position (exactly like real game)
           const startPos = game.gameState.zone.getHiddenAreaStartPosition('vim_secret_area');
           expect(startPos).toBeTruthy();
           game.gameState.cursor = game.gameState.cursor.moveTo(startPos);

--- a/tests/integration/game.test.js
+++ b/tests/integration/game.test.js
@@ -51,7 +51,7 @@ describe('VIM for Kids Game Integration', () => {
       const game = new VimForKidsGame();
       expect(game.currentLevel).toBe('level_1');
       expect(game.gameState.cursor).toBeDefined();
-      expect(game.gameState.availableKeys).toHaveLength(4);
+      expect(game.gameState.availableKeys).toHaveLength(7);
     });
 
     it('should render initial game state', () => {
@@ -71,7 +71,7 @@ describe('VIM for Kids Game Integration', () => {
     it('should have all VIM keys available initially', () => {
       game = new VimForKidsGame();
 
-      expect(game.gameState.availableKeys).toHaveLength(4);
+      expect(game.gameState.availableKeys).toHaveLength(7);
 
       const keyLetters = game.gameState.availableKeys.map((key) => key.key);
       expect(keyLetters).toContain('h');
@@ -194,7 +194,7 @@ describe('VIM for Kids Game Integration', () => {
       game.gameState.collectKey(targetKey);
 
       expect(game.gameState.collectedKeys.has('h')).toBe(true);
-      expect(game.gameState.availableKeys.length).toBe(3);
+      expect(game.gameState.availableKeys.length).toBe(6);
     });
 
     it('should collect key without popup when key is collected', () => {
@@ -205,7 +205,7 @@ describe('VIM for Kids Game Integration', () => {
 
       // Verify key was collected
       expect(game.gameState.collectedKeys.has('h')).toBe(true);
-      expect(game.gameState.availableKeys.length).toBe(3);
+      expect(game.gameState.availableKeys.length).toBe(6);
     });
 
             it('should update UI when key is collected', () => {
@@ -216,7 +216,7 @@ describe('VIM for Kids Game Integration', () => {
 
       // Verify key was collected in game state
       expect(game.gameState.collectedKeys.has('h')).toBe(true);
-      expect(game.gameState.availableKeys.length).toBe(3);
+      expect(game.gameState.availableKeys.length).toBe(6);
     });
 
     it('should collect keys placed in grass area', () => {


### PR DESCRIPTION
## Summary
- Level 1's secret grove used to flip in only when the player crossed the gate, which triggered `map.expandDimensions` mid-game and forced the camera to rescale (the "resolution problem").
- Now `revealWhen: 'always'` is honored at zone construction. The grove's tiles/decorations/labels/keys/gems/meters are part of the map before the first render, so dimensions are stable.
- The gate still locks until `h/j/k/l` are collected; players just walk through it onto the grove naturally instead of being teleported.

## Test plan
- [x] `npx jest` — 1903/1903 pass
- [x] Tests updated to the new totals (7 vim keys, 242 text labels, gate gating on h/j/k/l only)
- [ ] Manual: open level 1, confirm the grove is visible from the very first frame and the camera/zoom doesn't jump when the player crosses the gate